### PR TITLE
feat: support server side session

### DIFF
--- a/bindings/nodejs/tests/binding.js
+++ b/bindings/nodejs/tests/binding.js
@@ -118,7 +118,7 @@ Then("Stream load and Select should be equal", async function () {
   ];
   const progress = await this.conn.streamLoad(`INSERT INTO test VALUES`, values);
   assert.equal(progress.writeRows, 3);
-  assert.equal(progress.writeBytes, 185);
+  assert.equal(progress.writeBytes, 187);
 
   const rows = await this.conn.queryIter("SELECT * FROM test");
   const ret = [];

--- a/bindings/python/tests/asyncio/steps/binding.py
+++ b/bindings/python/tests/asyncio/steps/binding.py
@@ -136,7 +136,7 @@ async def _(context):
     ]
     progress = await context.conn.stream_load("INSERT INTO test VALUES", values)
     assert progress.write_rows == 3, f"progress.write_rows: {progress.write_rows}"
-    assert progress.write_bytes == 185, f"progress.write_bytes: {progress.write_bytes}"
+    assert progress.write_bytes == 187, f"progress.write_bytes: {progress.write_bytes}"
 
     rows = await context.conn.query_iter("SELECT * FROM test")
     ret = []

--- a/bindings/python/tests/blocking/steps/binding.py
+++ b/bindings/python/tests/blocking/steps/binding.py
@@ -128,7 +128,7 @@ def _(context):
     ]
     progress = context.conn.stream_load("INSERT INTO test VALUES", values)
     assert progress.write_rows == 3, f"progress.write_rows: {progress.write_rows}"
-    assert progress.write_bytes == 185, f"progress.write_bytes: {progress.write_bytes}"
+    assert progress.write_bytes == 187, f"progress.write_bytes: {progress.write_bytes}"
 
     rows = context.conn.query_iter("SELECT * FROM test")
     ret = []

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -373,13 +373,9 @@ pub async fn main() -> Result<()> {
             // Exit client if user login failed.
             if let Some(error) = err.downcast_ref::<databend_driver::Error>() {
                 match error {
-                    databend_driver::Error::Api(
-                        databend_client::error::Error::InvalidResponse(resp_err),
-                    ) => {
-                        if resp_err.code == 401 {
-                            println!("Authenticate failed wrong password user {}", user);
-                            return Ok(());
-                        }
+                    databend_driver::Error::Api(databend_client::error::Error::AuthFailure(_)) => {
+                        println!("Authenticate failed wrong password user {}", user);
+                        return Ok(());
                     }
                     databend_driver::Error::Arrow(arrow::error::ArrowError::IpcError(ipc_err)) => {
                         if ipc_err.contains("Unauthenticated") {

--- a/cli/src/session.rs
+++ b/cli/src/session.rs
@@ -106,11 +106,9 @@ impl Session {
                 Err(err) => {
                     match err {
                         databend_driver::Error::Api(
-                            databend_client::error::Error::InvalidResponse(ref resp_err),
+                            databend_client::error::Error::AuthFailure(_),
                         ) => {
-                            if resp_err.code == 401 {
-                                return Err(err.into());
-                            }
+                            return Err(err.into());
                         }
                         databend_driver::Error::Arrow(arrow::error::ArrowError::IpcError(
                             ref ipc_err,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,11 +22,12 @@ native-tls = ["reqwest/native-tls"]
 tokio-stream = { workspace = true }
 
 async-trait = "0.1"
+cookie = "0.18.1"
 log = "0.4"
 once_cell = "1.18"
 parking_lot = "0.12.3"
 percent-encoding = "2.3"
-reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "stream", "cookies"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 tokio = { version = "1.34", features = ["macros"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,7 +21,6 @@ native-tls = ["reqwest/native-tls"]
 [dependencies]
 tokio-stream = { workspace = true }
 
-async-trait = "0.1"
 cookie = "0.18.1"
 log = "0.4"
 once_cell = "1.18"

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -19,6 +19,9 @@ use crate::error::{Error, Result};
 #[async_trait::async_trait]
 pub trait Auth: Sync + Send {
     async fn wrap(&self, builder: RequestBuilder) -> Result<RequestBuilder>;
+    fn can_reload(&self) -> bool {
+        false
+    }
     fn username(&self) -> String;
 }
 
@@ -96,6 +99,10 @@ impl Auth for AccessTokenFileAuth {
                 ))
             })?;
         Ok(builder.bearer_auth(token.trim()))
+    }
+
+    fn can_reload(&self) -> bool {
+        true
     }
 
     fn username(&self) -> String {

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -16,9 +16,8 @@ use reqwest::RequestBuilder;
 
 use crate::error::{Error, Result};
 
-#[async_trait::async_trait]
 pub trait Auth: Sync + Send {
-    async fn wrap(&self, builder: RequestBuilder) -> Result<RequestBuilder>;
+    fn wrap(&self, builder: RequestBuilder) -> Result<RequestBuilder>;
     fn can_reload(&self) -> bool {
         false
     }
@@ -40,9 +39,8 @@ impl BasicAuth {
     }
 }
 
-#[async_trait::async_trait]
 impl Auth for BasicAuth {
-    async fn wrap(&self, builder: RequestBuilder) -> Result<RequestBuilder> {
+    fn wrap(&self, builder: RequestBuilder) -> Result<RequestBuilder> {
         Ok(builder.basic_auth(&self.username, Some(self.password.inner())))
     }
 
@@ -64,9 +62,8 @@ impl AccessTokenAuth {
     }
 }
 
-#[async_trait::async_trait]
 impl Auth for AccessTokenAuth {
-    async fn wrap(&self, builder: RequestBuilder) -> Result<RequestBuilder> {
+    fn wrap(&self, builder: RequestBuilder) -> Result<RequestBuilder> {
         Ok(builder.bearer_auth(self.token.inner()))
     }
 
@@ -87,17 +84,14 @@ impl AccessTokenFileAuth {
     }
 }
 
-#[async_trait::async_trait]
 impl Auth for AccessTokenFileAuth {
-    async fn wrap(&self, builder: RequestBuilder) -> Result<RequestBuilder> {
-        let token = tokio::fs::read_to_string(&self.token_file)
-            .await
-            .map_err(|e| {
-                Error::IO(format!(
-                    "cannot read access token from file {}: {}",
-                    self.token_file, e
-                ))
-            })?;
+    fn wrap(&self, builder: RequestBuilder) -> Result<RequestBuilder> {
+        let token = std::fs::read_to_string(&self.token_file).map_err(|e| {
+            Error::IO(format!(
+                "cannot read access token from file {}: {}",
+                self.token_file, e
+            ))
+        })?;
         Ok(builder.bearer_auth(token.trim()))
     }
 

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -223,8 +223,16 @@ impl APIClient {
             Some(n) => n,
             None => format!("databend-client-rust/{}", VERSION.as_str()),
         };
+        let cookie_provider = GlobalCookieStore::new();
+        let cookie = HeaderValue::from_str("cookie_enabled=true").unwrap();
+        let mut initial_cookies = [&cookie].into_iter();
+        cookie_provider.set_cookies(
+            &mut initial_cookies,
+            &Url::parse("https://a.com").unwrap(),
+        );
         let mut cli_builder = HttpClient::builder()
             .user_agent(ua)
+            .cookie_provider(Arc::new(cookie_provider))
             .pool_idle_timeout(Duration::from_secs(1));
         #[cfg(any(feature = "rustls", feature = "native-tls"))]
         if self.scheme == "https" {

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -13,31 +13,39 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::mem;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
-
-use log::{info, warn};
-use once_cell::sync::Lazy;
-use percent_encoding::percent_decode_str;
-use reqwest::header::HeaderMap;
-use reqwest::multipart::{Form, Part};
-use reqwest::{Body, Client as HttpClient};
-use tokio::sync::Mutex;
-use tokio_retry::strategy::{jitter, ExponentialBackoff};
-use tokio_retry::Retry;
-use tokio_util::io::ReaderStream;
-use url::Url;
+use std::time::{Duration, Instant};
 
 use crate::auth::{AccessTokenAuth, AccessTokenFileAuth, Auth, BasicAuth};
+use crate::error_code::{need_refresh_token, ResponseWithErrorCode};
+use crate::global_cookie_store::GlobalCookieStore;
+use crate::login::{
+    LoginInfo, LoginRequest, LoginResponse, LogoutRequest, RefreshResponse,
+    RefreshSessionTokenRequest,
+};
 use crate::presign::{presign_upload_to_stage, PresignMode, PresignedResponse, Reader};
-use crate::session::SessionState;
 use crate::stage::StageLocation;
 use crate::{
     error::{Error, Result},
     request::{PaginationConfig, QueryRequest, StageAttachmentConfig},
-    response::{QueryError, QueryResponse},
+    response::QueryResponse,
+    session::SessionState,
 };
+use log::{info, warn};
+use once_cell::sync::Lazy;
+use percent_encoding::percent_decode_str;
+use reqwest::cookie::CookieStore;
+use reqwest::header::{HeaderMap, HeaderValue};
+use reqwest::multipart::{Form, Part};
+use reqwest::{Body, Client as HttpClient, Request, RequestBuilder, Response, StatusCode};
+use serde::Deserialize;
+use tokio::sync::Mutex;
+use tokio::time::sleep;
+use tokio_retry::strategy::jitter;
+use tokio_util::io::ReaderStream;
+use url::Url;
 
 const HEADER_QUERY_ID: &str = "X-DATABEND-QUERY-ID";
 const HEADER_TENANT: &str = "X-DATABEND-TENANT";
@@ -64,9 +72,12 @@ pub struct APIClient {
     auth: Arc<dyn Auth>,
 
     tenant: Option<String>,
-    warehouse: Arc<Mutex<Option<String>>>,
+    warehouse: Arc<parking_lot::Mutex<Option<String>>>,
     session_state: Arc<Mutex<SessionState>>,
     route_hint: Arc<RouteHintGenerator>,
+
+    disable_session_token: bool,
+    login_info: Option<Arc<parking_lot::Mutex<(LoginInfo, Instant)>>>,
 
     wait_time_secs: Option<i64>,
     max_rows_in_buffer: Option<i64>,
@@ -86,6 +97,9 @@ impl APIClient {
         let mut client = Self::from_dsn(dsn).await?;
         client.build_client(name).await?;
         client.check_presign().await?;
+        if !client.disable_session_token {
+            client.login().await?;
+        }
         Ok(client)
     }
 
@@ -144,7 +158,7 @@ impl APIClient {
                     client.tenant = Some(v.to_string());
                 }
                 "warehouse" => {
-                    client.warehouse = Arc::new(Mutex::new(Some(v.to_string())));
+                    client.warehouse = Arc::new(parking_lot::Mutex::new(Some(v.to_string())));
                 }
                 "role" => role = Some(v.to_string()),
                 "sslmode" => match v.as_ref() {
@@ -165,6 +179,18 @@ impl APIClient {
                 }
                 "access_token_file" => {
                     client.auth = Arc::new(AccessTokenFileAuth::new(v));
+                }
+                "session_token" => {
+                    client.disable_session_token = match v.as_ref() {
+                        "disable" => true,
+                        "enable" => false,
+                        _ => {
+                            return Err(Error::BadArgument(format!(
+                                "Invalid value for session_token: {}",
+                                v
+                            )))
+                        }
+                    }
                 }
                 _ => {
                     session_settings.insert(k.to_string(), v.to_string());
@@ -234,7 +260,7 @@ impl APIClient {
     }
 
     pub async fn current_warehouse(&self) -> Option<String> {
-        let guard = self.warehouse.lock().await;
+        let guard = self.warehouse.lock();
         guard.clone()
     }
 
@@ -280,7 +306,7 @@ impl APIClient {
         // process warehouse changed via session settings
         if let Some(settings) = session.settings.as_ref() {
             if let Some(v) = settings.get("warehouse") {
-                let mut warehouse = self.warehouse.lock().await;
+                let mut warehouse = self.warehouse.lock();
                 *warehouse = Some(v.clone());
             }
         }
@@ -302,59 +328,56 @@ impl APIClient {
     }
 
     pub async fn start_query(&self, sql: &str) -> Result<QueryResponse> {
-        info!("start query: {}", sql);
+        self.start_query_inner(sql, None).await
+    }
+
+    async fn wrap_auth_or_session_token(&self, builder: RequestBuilder) -> Result<RequestBuilder> {
+        if let Some(info) = &self.login_info {
+            let info = info.lock();
+            Ok(builder.bearer_auth(info.0.session_token.clone()))
+        } else {
+            self.auth.wrap(builder).await
+        }
+    }
+
+    async fn start_query_inner(
+        &self,
+        sql: &str,
+        stage_attachment_config: Option<StageAttachmentConfig<'_>>,
+    ) -> Result<QueryResponse> {
         if !self.in_active_transaction().await {
             self.route_hint.next();
         }
+        let endpoint = self.endpoint.join("v1/query")?;
+
+        // body
         let session_state = self.session_state().await;
         let need_sticky = session_state.need_sticky.unwrap_or(false);
         let req = QueryRequest::new(sql)
             .with_pagination(self.make_pagination())
-            .with_session(Some(session_state));
-        let endpoint = self.endpoint.join("v1/query")?;
+            .with_session(Some(session_state))
+            .with_stage_attachment(stage_attachment_config);
+
+        // headers
         let query_id = self.gen_query_id();
-        let mut headers = self.make_headers(&query_id).await?;
+        let mut headers = self.make_headers(Some(&query_id))?;
         if need_sticky {
             if let Some(node_id) = self.last_node_id() {
                 headers.insert(HEADER_STICKY_NODE, node_id.parse()?);
             }
         }
         let mut builder = self.cli.post(endpoint.clone()).json(&req);
-        builder = self.auth.wrap(builder).await?;
-        let mut resp = builder.headers(headers.clone()).send().await?;
-        let mut retries = 3;
-        while resp.status() != 200 {
-            if resp.status() != 503 || retries <= 0 {
-                break;
-            }
-            retries -= 1;
-            let mut builder = self.cli.post(endpoint.clone()).json(&req);
-            builder = self.auth.wrap(builder).await?;
-            resp = builder.headers(headers.clone()).send().await?;
-        }
-        if resp.status() != 200 {
-            if resp.status() == 401 {
-                let resp_err = QueryError {
-                    code: resp.status().as_u16(),
-                    message: resp.text().await.unwrap_or_default(),
-                    detail: None,
-                };
-                return Err(Error::InvalidResponse(resp_err));
-            }
-            return Err(Error::Request(format!(
-                "Start Query failed with status {}: {}",
-                resp.status(),
-                resp.text().await?
-            )));
-        }
-
-        if let Some(route_hint) = resp.headers().get(HEADER_ROUTE_HINT) {
+        builder = self.wrap_auth_or_session_token(builder).await?;
+        let request = builder.headers(headers.clone()).build()?;
+        let response = self.query_request_helper(request, true, true).await?;
+        if let Some(route_hint) = response.headers().get(HEADER_ROUTE_HINT) {
             self.route_hint.set(route_hint.to_str().unwrap_or_default());
         }
-        let result: QueryResponse = resp.json().await?;
+        let body = response.bytes().await?;
+        let result: QueryResponse = json_from_slice(&body)?;
         self.handle_session(&result.session).await;
         if let Some(err) = result.error {
-            return Err(Error::InvalidResponse(err));
+            return Err(Error::QueryFailed(err));
         }
         self.handle_warnings(&result);
         Ok(result)
@@ -368,46 +391,28 @@ impl APIClient {
     ) -> Result<QueryResponse> {
         info!("query page: {}", next_uri);
         let endpoint = self.endpoint.join(next_uri)?;
-        let headers = self.make_headers(query_id).await?;
-        let retry_strategy = ExponentialBackoff::from_millis(10).map(jitter).take(3);
-        let req = || async {
-            let mut builder = self.cli.get(endpoint.clone());
-            builder = self.auth.wrap(builder).await?;
-            builder
-                .headers(headers.clone())
-                .header(HEADER_STICKY_NODE, node_id)
-                .timeout(self.page_request_timeout)
-                .send()
-                .await
-                .map_err(Error::from)
-        };
-        let resp = Retry::spawn(retry_strategy, req).await?;
-        if resp.status() != 200 {
-            // TODO(liyz): currently it's not possible to distinguish between session timeout and server crashed
-            if resp.status() == 404 {
-                return Err(Error::SessionTimeout(resp.text().await?));
+        let headers = self.make_headers(Some(query_id))?;
+        let mut builder = self.cli.get(endpoint.clone());
+        builder = self.wrap_auth_or_session_token(builder).await?;
+        let request = builder
+            .headers(headers.clone())
+            .header(HEADER_STICKY_NODE, node_id)
+            .timeout(self.page_request_timeout)
+            .build()?;
+
+        let response = self.query_request_helper(request, false, true).await?;
+        let body = response.bytes().await?;
+        let resp: QueryResponse = json_from_slice(&body).map_err(|e| {
+            if let Error::Logic(status, ec) = &e {
+                if *status == 404 {
+                    return Error::QueryNotFound(ec.message.clone());
+                }
             }
-            if resp.status() == 401 {
-                let resp_err = QueryError {
-                    code: resp.status().as_u16(),
-                    message: resp.text().await.unwrap_or_default(),
-                    detail: None,
-                };
-                return Err(Error::InvalidResponse(resp_err));
-            }
-            return Err(Error::Request(format!(
-                "Query Page failed with status {}: {}",
-                resp.status(),
-                resp.text().await?
-            )));
-        }
-        let resp: QueryResponse = resp.json().await?;
+            e
+        })?;
         self.handle_session(&resp.session).await;
-        // TODO: duplicate warnings with start_query,
-        // maybe we should only print warnings on final response
-        // self.handle_warnings(&resp);
         match resp.error {
-            Some(err) => Err(Error::InvalidResponse(err)),
+            Some(err) => Err(Error::QueryFailed(err)),
             None => Ok(resp),
         }
     }
@@ -415,17 +420,13 @@ impl APIClient {
     pub async fn kill_query(&self, query_id: &str, kill_uri: &str) -> Result<()> {
         info!("kill query: {}", kill_uri);
         let endpoint = self.endpoint.join(kill_uri)?;
-        let headers = self.make_headers(query_id).await?;
+        let headers = self.make_headers(Some(query_id))?;
         let mut builder = self.cli.post(endpoint.clone());
-        builder = self.auth.wrap(builder).await?;
+        builder = self.wrap_auth_or_session_token(builder).await?;
         let resp = builder.headers(headers.clone()).send().await?;
         if resp.status() != 200 {
-            let resp_err = QueryError {
-                code: resp.status().as_u16(),
-                message: format!("kill query failed: {}", resp.text().await?),
-                detail: None,
-            };
-            return Err(Error::InvalidResponse(resp_err));
+            return Err(Error::response_error(resp.status(), &resp.bytes().await?)
+                .with_context("kill query"));
         }
         Ok(())
     }
@@ -484,18 +485,20 @@ impl APIClient {
         Some(pagination)
     }
 
-    async fn make_headers(&self, query_id: &str) -> Result<HeaderMap> {
+    fn make_headers(&self, query_id: Option<&str>) -> Result<HeaderMap> {
         let mut headers = HeaderMap::new();
         if let Some(tenant) = &self.tenant {
             headers.insert(HEADER_TENANT, tenant.parse()?);
         }
-        let warehouse = self.warehouse.lock().await;
-        if let Some(warehouse) = &*warehouse {
+        let warehouse = self.warehouse.lock().clone();
+        if let Some(warehouse) = warehouse {
             headers.insert(HEADER_WAREHOUSE, warehouse.parse()?);
         }
         let route_hint = self.route_hint.current();
         headers.insert(HEADER_ROUTE_HINT, route_hint.parse()?);
-        headers.insert(HEADER_QUERY_ID, query_id.parse()?);
+        if let Some(query_id) = query_id {
+            headers.insert(HEADER_QUERY_ID, query_id.parse()?);
+        }
         Ok(headers)
     }
 
@@ -510,49 +513,12 @@ impl APIClient {
             "insert with stage: {}, format: {:?}, copy: {:?}",
             sql, file_format_options, copy_options
         );
-        let session_state = self.session_state().await;
-        let need_sticky = session_state.need_sticky.unwrap_or(false);
-
         let stage_attachment = Some(StageAttachmentConfig {
             location: stage,
             file_format_options: Some(file_format_options),
             copy_options: Some(copy_options),
         });
-        let req = QueryRequest::new(sql)
-            .with_pagination(self.make_pagination())
-            .with_session(Some(session_state))
-            .with_stage_attachment(stage_attachment);
-        let endpoint = self.endpoint.join("v1/query")?;
-        let query_id = self.gen_query_id();
-        let mut headers = self.make_headers(&query_id).await?;
-        if need_sticky {
-            if let Some(node_id) = self.last_node_id() {
-                headers.insert(HEADER_STICKY_NODE, node_id.parse()?);
-            }
-        }
-        let mut builder = self.cli.post(endpoint.clone()).json(&req);
-        builder = self.auth.wrap(builder).await?;
-        let mut resp = builder.headers(headers.clone()).send().await?;
-        let mut retries = 3;
-        while resp.status() != 200 {
-            if resp.status() != 503 || retries <= 0 {
-                break;
-            }
-            retries -= 1;
-            let mut builder = self.cli.post(endpoint.clone()).json(&req);
-            builder = self.auth.wrap(builder).await?;
-            resp = builder.headers(headers.clone()).send().await?;
-        }
-        if resp.status() != 200 {
-            let resp_err = QueryError {
-                code: resp.status().as_u16(),
-                message: resp.text().await?,
-                detail: None,
-            };
-            return Err(Error::InvalidResponse(resp_err));
-        }
-
-        let resp: QueryResponse = resp.json().await?;
+        let resp = self.start_query_inner(sql, stage_attachment).await?;
         let resp = self.wait_for_query(resp).await?;
         Ok(resp)
     }
@@ -562,19 +528,19 @@ impl APIClient {
         let sql = format!("PRESIGN UPLOAD {}", stage);
         let resp = self.query(&sql).await?;
         if resp.data.len() != 1 {
-            return Err(Error::Request(
+            return Err(Error::Decode(
                 "Empty response from server for presigned request".to_string(),
             ));
         }
         if resp.data[0].len() != 3 {
-            return Err(Error::Request(
+            return Err(Error::Decode(
                 "Invalid response from server for presigned request".to_string(),
             ));
         }
         // resp.data[0]: [ "PUT", "{\"host\":\"s3.us-east-2.amazonaws.com\"}", "https://s3.us-east-2.amazonaws.com/query-storage-xxxxx/tnxxxxx/stage/user/xxxx/xxx?" ]
         let method = resp.data[0][0].clone().unwrap_or_default();
         if method != "PUT" {
-            return Err(Error::Request(format!(
+            return Err(Error::Decode(format!(
                 "Invalid method for presigned upload request: {}",
                 method
             )));
@@ -613,27 +579,306 @@ impl APIClient {
         size: u64,
     ) -> Result<()> {
         info!("upload to stage with stream: {}, size: {}", stage, size);
+        if let Some(info) = self.need_pre_refresh_session().await {
+            self.refresh_session_token(info).await?;
+        }
         let endpoint = self.endpoint.join("v1/upload_to_stage")?;
         let location = StageLocation::try_from(stage)?;
         let query_id = self.gen_query_id();
-        let mut headers = self.make_headers(&query_id).await?;
+        let mut headers = self.make_headers(Some(&query_id))?;
         headers.insert(HEADER_STAGE_NAME, location.name.parse()?);
         let stream = Body::wrap_stream(ReaderStream::new(data));
         let part = Part::stream_with_length(stream, size).file_name(location.path);
         let form = Form::new().part("upload", part);
         let mut builder = self.cli.put(endpoint.clone());
-        builder = self.auth.wrap(builder).await?;
+        builder = self.wrap_auth_or_session_token(builder).await?;
         let resp = builder.headers(headers).multipart(form).send().await?;
         let status = resp.status();
-        let body = resp.bytes().await?;
         if status != 200 {
-            return Err(Error::Request(format!(
-                "Stage Upload Failed: {}",
-                String::from_utf8_lossy(&body)
-            )));
+            return Err(
+                Error::response_error(status, &resp.bytes().await?).with_context("upload_to_stage")
+            );
         }
         Ok(())
     }
+
+    pub async fn login(&mut self) -> Result<()> {
+        let endpoint = self.endpoint.join("/v1/session/login")?;
+        let headers = self.make_headers(None)?;
+        let body = LoginRequest::from(&*self.session_state.lock().await);
+        let builder = self.cli.post(endpoint.clone()).json(&body);
+        let builder = self.auth.wrap(builder).await?;
+        let request = builder
+            .headers(headers.clone())
+            .timeout(self.connect_timeout)
+            .build()?;
+        let response = self.query_request_helper(request, true, false).await;
+        let response = match response {
+            Ok(r) => r,
+            Err(Error::Logic(status, _ec)) if status == 404 => {
+                // old server
+                return Ok(());
+            }
+            Err(e) => return Err(e),
+        };
+        let body = response.bytes().await?;
+        let response = json_from_slice(&body)?;
+        match response {
+            LoginResponse::Err { error } => return Err(Error::AuthFailure(error)),
+            LoginResponse::Ok(info) => {
+                self.login_info = Some(Arc::new(parking_lot::Mutex::new((info, Instant::now()))))
+            }
+        }
+        Ok(())
+    }
+
+    pub fn build_log_out_request(&self, login_info: LoginInfo) -> Result<Request> {
+        let endpoint = self.endpoint.join("/v1/session/logout")?;
+        let body = LogoutRequest {
+            refresh_token: login_info.refresh_token.clone(),
+        };
+        let headers = self.make_headers(None)?;
+        let req = self
+            .cli
+            .post(endpoint.clone())
+            .json(&body)
+            .headers(headers.clone())
+            .bearer_auth(login_info.session_token.clone())
+            .build()?;
+        Ok(req)
+    }
+
+    pub async fn close(&mut self) -> Result<()> {
+        if let Some(info) = mem::take(&mut self.login_info) {
+            let req = self.build_log_out_request(info.lock().0.clone())?;
+            self.cli.execute(req).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn refresh_session_token(
+        &self,
+        self_login_info: Arc<parking_lot::Mutex<(LoginInfo, Instant)>>,
+    ) -> Result<()> {
+        let login_info = { self_login_info.lock().clone() };
+        let endpoint = self.endpoint.join("/v1/session/refresh")?;
+        let body = RefreshSessionTokenRequest {
+            session_token: login_info.0.session_token.clone(),
+        };
+        let headers = self.make_headers(None)?;
+        let request = self
+            .cli
+            .post(endpoint.clone())
+            .json(&body)
+            .headers(headers.clone())
+            .bearer_auth(login_info.0.refresh_token.clone())
+            .timeout(self.connect_timeout)
+            .build()?;
+
+        // avoid recursively call request_helper
+        for i in 0..3 {
+            let req = request.try_clone().expect("request not cloneable");
+            match self.cli.execute(req).await {
+                Ok(response) => {
+                    let status = response.status();
+                    let body = response.bytes().await?;
+                    if status == StatusCode::OK {
+                        let response = json_from_slice(&body)?;
+                        return match response {
+                            RefreshResponse::Err { error } => Err(Error::AuthFailure(error)),
+                            RefreshResponse::Ok(info) => {
+                                *self_login_info.lock() = (
+                                    LoginInfo {
+                                        session_token: info.session_token,
+                                        refresh_token: info.refresh_token,
+                                        session_token_ttl_in_secs: info.session_token_ttl_in_secs,
+                                        ..login_info.0.clone()
+                                    },
+                                    Instant::now(),
+                                );
+                                Ok(())
+                            }
+                        };
+                    }
+                    if status != StatusCode::SERVICE_UNAVAILABLE || i >= 2 {
+                        return Err(Error::response_error(status, &body));
+                    }
+                }
+                Err(err) => {
+                    if !(err.is_timeout() || err.is_connect()) || i > 2 {
+                        return Err(Error::Request(err.to_string()));
+                    }
+                }
+            };
+            sleep(jitter(Duration::from_secs(10))).await;
+        }
+        Ok(())
+    }
+
+    async fn need_pre_refresh_session(
+        &self,
+    ) -> Option<Arc<parking_lot::Mutex<(LoginInfo, Instant)>>> {
+        if let Some(login_info) = &self.login_info {
+            let (start, ttl) = {
+                let guard = login_info.lock();
+                (guard.1, guard.0.session_token_ttl_in_secs)
+            };
+            if Instant::now() > start + Duration::from_secs(ttl) {
+                return Some(login_info.clone());
+            }
+        }
+        None
+    }
+
+    /// return Ok if and only if status code is 200.
+    ///
+    /// retry on
+    ///   - network errors
+    ///   - (optional) 503
+    ///
+    /// refresh databend token or reload jwt token if needed.
+    async fn query_request_helper(
+        &self,
+        mut request: Request,
+        retry_if_503: bool,
+        refresh_if_401: bool,
+    ) -> std::result::Result<Response, Error> {
+        let mut refreshed = false;
+        let mut retries = 0;
+        loop {
+            let req = request.try_clone().expect("request not cloneable");
+            let (err, retry): (Error, bool) = match self.cli.execute(req).await {
+                Ok(response) => {
+                    let status = response.status();
+                    if status == StatusCode::OK {
+                        return Ok(response);
+                    }
+                    let body = response.bytes().await?;
+                    if retry_if_503 || status == StatusCode::SERVICE_UNAVAILABLE {
+                        // waiting for server to start
+                        (Error::response_error(status, &body), true)
+                    } else {
+                        let resp = serde_json::from_slice::<ResponseWithErrorCode>(&body);
+                        match resp {
+                            Ok(r) => {
+                                let e = r.error;
+                                if status == StatusCode::UNAUTHORIZED {
+                                    request.headers_mut().remove(reqwest::header::AUTHORIZATION);
+                                    if let Some(login_info) = &self.login_info {
+                                        info!(
+                                            "will retry {} after refresh token on auth error {}",
+                                            request.url(),
+                                            e
+                                        );
+                                        let retry = if need_refresh_token(e.code)
+                                            && !refreshed
+                                            && refresh_if_401
+                                        {
+                                            self.refresh_session_token(login_info.clone()).await?;
+                                            refreshed = true;
+                                            true
+                                        } else {
+                                            false
+                                        };
+                                        (Error::AuthFailure(e), retry)
+                                    } else if self.auth.can_reload() {
+                                        info!(
+                                            "will retry {} after reload token on auth error {}",
+                                            request.url(),
+                                            e
+                                        );
+                                        let builder = RequestBuilder::from_parts(
+                                            HttpClient::new(),
+                                            request.try_clone().unwrap(),
+                                        );
+                                        let builder = self.auth.wrap(builder).await?;
+                                        request = builder.build()?;
+                                        (Error::AuthFailure(e), true)
+                                    } else {
+                                        (Error::AuthFailure(e), false)
+                                    }
+                                } else {
+                                    (Error::Logic(status, e), false)
+                                }
+                            }
+                            Err(_) => (
+                                Error::Response {
+                                    status,
+                                    msg: String::from_utf8_lossy(&body).to_string(),
+                                },
+                                true,
+                            ),
+                        }
+                    }
+                }
+                Err(err) => (
+                    Error::Request(err.to_string()),
+                    err.is_timeout() || err.is_connect(),
+                ),
+            };
+            if !retry {
+                return Err(err.with_context(&format!(
+                    "fail to {} {} after 3 reties",
+                    request.method(),
+                    request.url()
+                )));
+            }
+            match &err {
+                Error::AuthFailure(_) => {
+                    if refreshed {
+                        retries = 0;
+                    } else if retries == 2 {
+                        return Err(err.with_context(&format!(
+                            "fail to {} {} after 3 reties",
+                            request.method(),
+                            request.url()
+                        )));
+                    }
+                }
+                _ => {
+                    if retries == 2 {
+                        return Err(err.with_context(&format!(
+                            "fail to {} {} after 3 reties",
+                            request.method(),
+                            request.url()
+                        )));
+                    }
+                    retries += 1;
+                    info!(
+                        "will retry {} the {retries}th times on error {}",
+                        request.url(),
+                        err
+                    );
+                }
+            }
+            sleep(jitter(Duration::from_secs(10))).await;
+        }
+    }
+}
+
+impl Drop for APIClient {
+    fn drop(&mut self) {
+        if let Some(info) = mem::take(&mut self.login_info) {
+            let cli = self.cli.clone();
+            let req = self.build_log_out_request(info.lock().0.clone()).unwrap();
+            tokio::task::spawn(async move {
+                cli.execute(req).await.ok();
+            });
+        }
+    }
+}
+
+fn json_from_slice<'a, T>(body: &'a [u8]) -> Result<T>
+where
+    T: Deserialize<'a>,
+{
+    serde_json::from_slice::<T>(body).map_err(|e| {
+        Error::Decode(format!(
+            "fail to decode JSON response: {}, body: {}",
+            e,
+            String::from_utf8_lossy(body)
+        ))
+    })
 }
 
 impl Default for APIClient {
@@ -645,7 +890,7 @@ impl Default for APIClient {
             host: "localhost".to_string(),
             port: 8000,
             tenant: None,
-            warehouse: Arc::new(Mutex::new(None)),
+            warehouse: Arc::new(parking_lot::Mutex::new(None)),
             auth: Arc::new(BasicAuth::new("root", "")) as Arc<dyn Auth>,
             session_state: Arc::new(Mutex::new(SessionState::default())),
             wait_time_secs: None,
@@ -657,6 +902,8 @@ impl Default for APIClient {
             presign: PresignMode::Auto,
             route_hint: Arc::new(RouteHintGenerator::new()),
             last_node_id: Arc::new(Default::default()),
+            disable_session_token: false,
+            login_info: None,
         }
     }
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -24,6 +24,7 @@ pub enum Error {
     // on accessing this next page uri.
     QueryExpired(String),
     InvalidResponse(response::QueryError),
+    AuthFailure(response::QueryError),
 }
 
 impl std::fmt::Display for Error {
@@ -39,6 +40,12 @@ impl std::fmt::Display for Error {
                     write!(f, "ResponseError with {}: {}\n{}", e.code, e.message, d)
                 }
                 _ => write!(f, "ResponseError with {}: {}", e.code, e.message),
+            },
+            Error::AuthFailure(e) => match &e.detail {
+                Some(d) if !d.is_empty() => {
+                    write!(f, "AuthFailure with {}: {}\n{}", e.code, e.message, d)
+                }
+                _ => write!(f, "AuthFailure with {}: {}", e.code, e.message),
             },
         }
     }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -22,7 +22,7 @@ pub enum Error {
     IO(String),
     // if you have not polled the next_page_uri for too long, the session will be expired, you'll get a 404
     // on accessing this next page uri.
-    SessionTimeout(String),
+    QueryExpired(String),
     InvalidResponse(response::QueryError),
 }
 
@@ -33,7 +33,7 @@ impl std::fmt::Display for Error {
             Error::BadArgument(msg) => write!(f, "BadArgument: {msg}"),
             Error::Request(msg) => write!(f, "RequestError: {msg}"),
             Error::IO(msg) => write!(f, "IOError: {msg}"),
-            Error::SessionTimeout(msg) => write!(f, "SessionExpired: {msg}"),
+            Error::QueryExpired(msg) => write!(f, "QueryExpired: {msg}"),
             Error::InvalidResponse(e) => match &e.detail {
                 Some(d) if !d.is_empty() => {
                     write!(f, "ResponseError with {}: {}\n{}", e.code, e.message, d)

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -12,41 +12,81 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::response;
+use crate::error_code::ErrorCode;
+use reqwest::StatusCode;
 
 #[derive(Debug)]
 pub enum Error {
-    Parsing(String),
+    WithContext(Box<Error>, String),
+
+    /// errors detected before sending request.
+    /// e.g. invalid DSN, header value, stage name.
     BadArgument(String),
-    Request(String),
+    /// errors when
+    /// 1. accessing local file and presign_url
+    /// 2. From(std::io::Error)
     IO(String),
-    // if you have not polled the next_page_uri for too long, the session will be expired, you'll get a 404
-    // on accessing this next page uri.
-    QueryExpired(String),
-    InvalidResponse(response::QueryError),
-    AuthFailure(response::QueryError),
+
+    /// send request error
+    Request(String),
+
+    /// http handler return 200, but body is invalid
+    /// 1. failed to decode body to Utf8 or JSON
+    /// 2. failed to decode result data
+    Decode(String),
+
+    /// http handler return 200, but query failed (.error != null)
+    QueryFailed(ErrorCode),
+
+    /// http handler return non-200, with JSON body of type QueryError.
+    Logic(StatusCode, ErrorCode),
+
+    /// other non-200 response
+    Response {
+        status: StatusCode,
+        msg: String,
+    },
+
+    /// the flowing are more detail type of Logic
+    ///
+    /// possible reasons:
+    ///  - expired: if you have not polled the next_page_uri for too long, the session will be expired, you'll get a 404
+    ///    on accessing this next page uri.
+    ///  - routed to another server
+    ///  - server restarted
+    ///
+    /// TODO: try to distinguish them
+    QueryNotFound(String),
+    AuthFailure(ErrorCode),
+}
+
+impl Error {
+    pub fn response_error(status: StatusCode, body: &[u8]) -> Self {
+        Self::Response {
+            status,
+            msg: String::from_utf8_lossy(body).to_string(),
+        }
+    }
+
+    pub fn with_context(self, ctx: &str) -> Self {
+        Error::WithContext(Box::new(self), ctx.to_string())
+    }
 }
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::Parsing(msg) => write!(f, "ParsingError: {msg}"),
+            Error::Decode(msg) => write!(f, "DecodeError: {msg}"),
             Error::BadArgument(msg) => write!(f, "BadArgument: {msg}"),
-            Error::Request(msg) => write!(f, "RequestError: {msg}"),
+            Error::Request(msg) => write!(f, "{msg}"),
+            Error::Response { msg, status } => write!(f, "ResponseError: ({status}){msg}"),
             Error::IO(msg) => write!(f, "IOError: {msg}"),
-            Error::QueryExpired(msg) => write!(f, "QueryExpired: {msg}"),
-            Error::InvalidResponse(e) => match &e.detail {
-                Some(d) if !d.is_empty() => {
-                    write!(f, "ResponseError with {}: {}\n{}", e.code, e.message, d)
-                }
-                _ => write!(f, "ResponseError with {}: {}", e.code, e.message),
-            },
-            Error::AuthFailure(e) => match &e.detail {
-                Some(d) if !d.is_empty() => {
-                    write!(f, "AuthFailure with {}: {}\n{}", e.code, e.message, d)
-                }
-                _ => write!(f, "AuthFailure with {}: {}", e.code, e.message),
-            },
+            Error::Logic(status_code, ec) => write!(f, "BadRequest:({status_code}){ec}"),
+            Error::QueryNotFound(msg) => write!(f, "QueryNotFound: {msg}"),
+            Error::QueryFailed(ec) => write!(f, "QueryFailed: {ec}"),
+            Error::AuthFailure(ec) => write!(f, "AuthFailure: {ec}"),
+
+            Error::WithContext(err, ctx) => write!(f, "fail to {ctx}: {err}"),
         }
     }
 }
@@ -57,25 +97,26 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 impl From<url::ParseError> for Error {
     fn from(e: url::ParseError) -> Self {
-        Error::Parsing(e.to_string())
+        Error::Decode(e.to_string())
     }
 }
 
 impl From<std::num::ParseIntError> for Error {
     fn from(e: std::num::ParseIntError) -> Self {
-        Error::Parsing(e.to_string())
+        Error::Decode(e.to_string())
     }
 }
 
+/// only used in make_headers
 impl From<reqwest::header::InvalidHeaderValue> for Error {
     fn from(e: reqwest::header::InvalidHeaderValue) -> Self {
-        Error::Parsing(e.to_string())
+        Error::BadArgument(e.to_string())
     }
 }
 
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
-        Error::Parsing(e.to_string())
+        Error::Decode(e.to_string())
     }
 }
 
@@ -93,6 +134,6 @@ impl From<std::io::Error> for Error {
 
 impl From<std::str::Utf8Error> for Error {
     fn from(e: std::str::Utf8Error) -> Self {
-        Error::Parsing(e.to_string())
+        Error::Decode(e.to_string())
     }
 }

--- a/core/src/error_code.rs
+++ b/core/src/error_code.rs
@@ -12,16 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod client;
+const SessionTokenExpired: u16 = 5100;
+const RefreshTokenExpired: u16 = 5100;
+const SessionTokenNotFound: u16 = 5100;
+const RefreshTokenNotFound: u16 = 5100;
 
-pub mod auth;
-pub mod error;
-pub mod error_code;
-mod login;
-pub mod presign;
-pub mod request;
-pub mod response;
-pub mod session;
-pub mod stage;
-
-pub use client::APIClient;
+pub fn need_renew_token(code: u16) -> bool {
+    code == SessionTokenExpired || code == SessionTokenNotFound
+}

--- a/core/src/error_code.rs
+++ b/core/src/error_code.rs
@@ -12,11 +12,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const SessionTokenExpired: u16 = 5100;
-const RefreshTokenExpired: u16 = 5100;
-const SessionTokenNotFound: u16 = 5100;
-const RefreshTokenNotFound: u16 = 5100;
+use serde::Deserialize;
+use std::fmt::{Display, Formatter};
 
-pub fn need_renew_token(code: u16) -> bool {
-    code == SessionTokenExpired || code == SessionTokenNotFound
+const SESSION_TOKEN_EXPIRED: u16 = 5101;
+const SESSION_TOKEN_NOT_FOUND: u16 = 5103;
+
+pub fn need_refresh_token(code: u16) -> bool {
+    code == SESSION_TOKEN_EXPIRED || code == SESSION_TOKEN_NOT_FOUND
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct ErrorCode {
+    pub code: u16,
+    pub message: String,
+    pub detail: Option<String>,
+}
+
+/// try to decode to this when status code is not 200.
+/// so the error field is expect to exist.
+#[derive(Deserialize, Debug)]
+pub struct ResponseWithErrorCode {
+    pub error: ErrorCode,
+}
+
+impl Display for ErrorCode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "[{}]{}.{}",
+            self.code,
+            self.message,
+            self.detail.clone().unwrap_or("".to_string())
+        )
+    }
 }

--- a/core/src/global_cookie_store.rs
+++ b/core/src/global_cookie_store.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use cookie::Cookie;
 use reqwest::cookie::CookieStore;
 use reqwest::header::HeaderValue;

--- a/core/src/global_cookie_store.rs
+++ b/core/src/global_cookie_store.rs
@@ -1,0 +1,47 @@
+use cookie::Cookie;
+use reqwest::cookie::CookieStore;
+use reqwest::header::HeaderValue;
+use std::collections::HashMap;
+use std::sync::RwLock;
+use url::Url;
+
+pub(crate) struct GlobalCookieStore {
+    cookies: RwLock<HashMap<String, Cookie<'static>>>,
+}
+
+impl GlobalCookieStore {
+    pub fn new() -> Self {
+        GlobalCookieStore {
+            cookies: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl CookieStore for GlobalCookieStore {
+    fn set_cookies(&self, cookie_headers: &mut dyn Iterator<Item = &HeaderValue>, _url: &Url) {
+        let iter = cookie_headers
+            .filter_map(|val| std::str::from_utf8(val.as_bytes()).ok())
+            .filter_map(|kv| Cookie::parse(kv).map(|c| c.into_owned()).ok());
+
+        let mut guard = self.cookies.write().unwrap();
+        for cookie in iter {
+            guard.insert(cookie.name().to_string(), cookie);
+        }
+    }
+
+    fn cookies(&self, _url: &Url) -> Option<HeaderValue> {
+        let guard = self.cookies.read().unwrap();
+        let s: String = guard
+            .values()
+            .map(|cookie| cookie.name_value())
+            .map(|(name, value)| format!("{name}={value}"))
+            .collect::<Vec<_>>()
+            .join("; ");
+
+        if s.is_empty() {
+            return None;
+        }
+
+        HeaderValue::from_str(&s).ok()
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -17,6 +17,7 @@ mod client;
 pub mod auth;
 pub mod error;
 pub mod error_code;
+mod global_cookie_store;
 mod login;
 pub mod presign;
 pub mod request;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,5 +24,4 @@ pub mod request;
 pub mod response;
 pub mod session;
 pub mod stage;
-
 pub use client::APIClient;

--- a/core/src/login.rs
+++ b/core/src/login.rs
@@ -1,0 +1,82 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use crate::request::SessionState;
+use crate::response::QueryError;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Debug)]
+pub struct LoginRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub database: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings: Option<BTreeMap<String, String>>,
+}
+
+impl From<&SessionState> for LoginRequest {
+    fn from(value: &SessionState) -> Self {
+        Self {
+            database: value.database.clone(),
+            role: value.role.clone(),
+            settings: value.settings.clone(),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct LoginInfo {
+    pub version: String,
+    pub session_id: String,
+    pub session_token: String,
+    pub session_token_validity_in_secs: u64,
+    pub refresh_token: String,
+    #[allow(dead_code)]
+    pub refresh_token_validity_in_secs: u64,
+}
+
+impl LoginInfo {
+    pub fn may_need_renew_token() {
+    }
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+pub enum LoginResponse {
+    Ok(LoginInfo),
+    Err { error: QueryError },
+}
+
+#[derive(Serialize, Debug)]
+pub struct RenewRequest {
+    pub session_token: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct RenewInfo {
+    pub session_token: String,
+    pub session_token_validity_in_secs: u64,
+    pub refresh_token: String,
+    pub refresh_token_validity_in_secs: u64,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+pub enum RenewResponse {
+    Ok(RenewInfo),
+    Err { error: QueryError },
+}

--- a/core/src/login.rs
+++ b/core/src/login.rs
@@ -53,8 +53,7 @@ pub struct SessionTokenInfo {
 #[derive(Deserialize, Debug, Clone)]
 pub struct LoginResponse {
     pub version: String,
-    #[serde(flatten)]
-    pub token_info: SessionTokenInfo,
+    pub tokens: Option<SessionTokenInfo>,
 }
 #[derive(Deserialize, Debug)]
 #[serde(untagged)]
@@ -73,9 +72,4 @@ pub struct RefreshSessionTokenRequest {
 pub enum RefreshResponse {
     Ok(SessionTokenInfo),
     Err { error: ErrorCode },
-}
-
-#[derive(Serialize, Debug)]
-pub struct LogoutRequest {
-    pub refresh_token: Option<String>,
 }

--- a/core/src/login.rs
+++ b/core/src/login.rs
@@ -43,23 +43,23 @@ fn default_session_token_ttl_in_secs() -> u64 {
 }
 
 #[derive(Deserialize, Debug, Clone)]
-pub struct LoginInfo {
-    pub version: String,
-    pub session_id: String,
+pub struct SessionTokenInfo {
     pub session_token: String,
     #[serde(default = "default_session_token_ttl_in_secs")]
     pub session_token_ttl_in_secs: u64,
     pub refresh_token: String,
 }
 
-impl LoginInfo {
-    pub fn may_need_refresh_token() {}
+#[derive(Deserialize, Debug, Clone)]
+pub struct LoginResponse {
+    pub version: String,
+    #[serde(flatten)]
+    pub token_info: SessionTokenInfo,
 }
-
 #[derive(Deserialize, Debug)]
 #[serde(untagged)]
-pub enum LoginResponse {
-    Ok(LoginInfo),
+pub enum LoginResponseResult {
+    Ok(LoginResponse),
     Err { error: ErrorCode },
 }
 
@@ -68,21 +68,14 @@ pub struct RefreshSessionTokenRequest {
     pub session_token: String,
 }
 
-#[derive(Deserialize, Debug, Clone)]
-pub struct RefreshInfo {
-    pub session_token: String,
-    pub session_token_ttl_in_secs: u64,
-    pub refresh_token: String,
-}
-
 #[derive(Deserialize, Debug)]
 #[serde(untagged)]
 pub enum RefreshResponse {
-    Ok(RefreshInfo),
+    Ok(SessionTokenInfo),
     Err { error: ErrorCode },
 }
 
 #[derive(Serialize, Debug)]
 pub struct LogoutRequest {
-    pub refresh_token: String,
+    pub refresh_token: Option<String>,
 }

--- a/core/src/response.rs
+++ b/core/src/response.rs
@@ -12,16 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use serde::Deserialize;
-
+use crate::error_code::ErrorCode;
 use crate::session::SessionState;
-
-#[derive(Deserialize, Debug)]
-pub struct QueryError {
-    pub code: u16,
-    pub message: String,
-    pub detail: Option<String>,
-}
+use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]
 pub struct QueryStats {
@@ -61,7 +54,7 @@ pub struct QueryResponse {
     pub schema: Vec<SchemaField>,
     pub data: Vec<Vec<Option<String>>>,
     pub state: String,
-    pub error: Option<QueryError>,
+    pub error: Option<ErrorCode>,
     // make it optional for backward compatibility
     pub warnings: Option<Vec<String>>,
     pub stats: QueryStats,

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -29,6 +29,8 @@ pub struct SessionState {
     pub txn_state: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub need_sticky: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub need_keep_alive: Option<bool>,
 
     // hide fields of no interest (but need to send back to server in next query)
     #[serde(flatten)]

--- a/core/src/stage.rs
+++ b/core/src/stage.rs
@@ -29,12 +29,12 @@ impl TryFrom<&str> for StageLocation {
     type Error = Error;
     fn try_from(s: &str) -> Result<Self> {
         if !s.starts_with('@') {
-            return Err(Error::Parsing(format!("Invalid stage location: {}", s)));
+            return Err(Error::BadArgument(format!("Invalid stage location: {}", s)));
         }
         let mut parts = s.splitn(2, '/');
         let name = parts
             .next()
-            .ok_or_else(|| Error::Parsing(format!("Invalid stage location: {}", s)))?
+            .ok_or_else(|| Error::BadArgument(format!("Invalid stage location: {}", s)))?
             .trim_start_matches('@');
         let path = parts.next().unwrap_or_default();
         Ok(Self {

--- a/deny.toml
+++ b/deny.toml
@@ -32,6 +32,7 @@ allow = [
     "MPL-2.0",
     "OpenSSL",
     "Unicode-DFS-2016",
+    "Unicode-3.0"
 ]
 
 [[licenses.clarify]]

--- a/deny.toml
+++ b/deny.toml
@@ -3,20 +3,10 @@ version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = [
-    "RUSTSEC-2023-0086",
-    "RUSTSEC-2024-0019",
     "RUSTSEC-2024-0332",
-    "RUSTSEC-2024-0348",
-    "RUSTSEC-2024-0349",
-    "RUSTSEC-2024-0350",
-    "RUSTSEC-2024-0351",
-    "RUSTSEC-2024-0352",
-    "RUSTSEC-2024-0353",
-    "RUSTSEC-2024-0359",
-    "RUSTSEC-2024-0367",
-    "RUSTSEC-2024-0371",
     "RUSTSEC-2024-0370",
-    "RUSTSEC-2024-0377"
+    "RUSTSEC-2024-0379",
+    "RUSTSEC-2024-0384"
 ]
 
 [licenses]

--- a/driver/src/rest_api.rs
+++ b/driver/src/rest_api.rs
@@ -27,7 +27,6 @@ use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_stream::Stream;
 
-use databend_client::error::Error as ClientError;
 use databend_client::presign::PresignedResponse;
 use databend_client::response::QueryResponse;
 use databend_client::APIClient;
@@ -39,7 +38,7 @@ use crate::conn::{Connection, ConnectionInfo, Reader};
 
 #[derive(Clone)]
 pub struct RestAPIConnection {
-    client: APIClient,
+    client: Arc<APIClient>,
 }
 
 #[async_trait]
@@ -151,9 +150,6 @@ impl Connection for RestAPIConnection {
             .client
             .insert_with_stage(sql, &stage, file_format_options, copy_options)
             .await?;
-        if let Some(err) = resp.error {
-            return Err(ClientError::InvalidResponse(err).into());
-        }
         Ok(ServerStats::from(resp.stats))
     }
 
@@ -202,7 +198,9 @@ impl Connection for RestAPIConnection {
 impl<'o> RestAPIConnection {
     pub async fn try_create(dsn: &str, name: String) -> Result<Self> {
         let client = APIClient::new(dsn, Some(name)).await?;
-        Ok(Self { client })
+        Ok(Self {
+            client: Arc::new(client),
+        })
     }
 
     async fn wait_for_schema(&self, resp: QueryResponse) -> Result<QueryResponse> {
@@ -244,7 +242,7 @@ impl<'o> RestAPIConnection {
 type PageFut = Pin<Box<dyn Future<Output = Result<QueryResponse>> + Send>>;
 
 pub struct RestAPIRows {
-    client: APIClient,
+    client: Arc<APIClient>,
     schema: SchemaRef,
     data: VecDeque<Vec<Option<String>>>,
     stats: Option<ServerStats>,
@@ -255,7 +253,7 @@ pub struct RestAPIRows {
 }
 
 impl RestAPIRows {
-    fn from_response(client: APIClient, resp: QueryResponse) -> Result<(Schema, Self)> {
+    fn from_response(client: Arc<APIClient>, resp: QueryResponse) -> Result<(Schema, Self)> {
         let schema: Schema = resp.schema.try_into()?;
         let rows = Self {
             client,

--- a/driver/src/rest_api.rs
+++ b/driver/src/rest_api.rs
@@ -49,8 +49,8 @@ impl Connection for RestAPIConnection {
             host: self.client.host.clone(),
             port: self.client.port,
             user: self.client.username(),
-            database: self.client.current_database().await,
-            warehouse: self.client.current_warehouse().await,
+            database: self.client.current_database(),
+            warehouse: self.client.current_warehouse(),
         }
     }
 

--- a/driver/tests/driver/main.rs
+++ b/driver/tests/driver/main.rs
@@ -19,3 +19,4 @@ mod load;
 mod select_iter;
 mod select_simple;
 mod session;
+mod temp_table;

--- a/driver/tests/driver/session.rs
+++ b/driver/tests/driver/session.rs
@@ -53,30 +53,33 @@ async fn set_timezone_with_dsn() {
     assert_eq!(val, "Europe/London");
 }
 
-
 #[tokio::test]
 async fn change_password() {
     let dsn = option_env!("TEST_DATABEND_DSN").unwrap_or(DEFAULT_DSN);
     if dsn.starts_with("databend+flight://") {
-        // skip dsn variable test for flight
         return;
     }
     let client = Client::new(dsn.to_string());
     let conn = client.get_conn().await.unwrap();
-    let n= conn.exec("drop user if exists u1 ").await.unwrap();
+    let n = conn.exec("drop user if exists u1 ").await.unwrap();
     assert_eq!(n, 0);
-    let n= conn.exec("create user u1 identified by 'p1' ").await.unwrap();
+    let n = conn
+        .exec("create user u1 identified by 'p1' ")
+        .await
+        .unwrap();
     assert_eq!(n, 0);
 
-
-    let dsn="databend://u1:p1@localhost:8000/default?sslmode=disable&session_token=enable";
+    let dsn = "databend://u1:p1@localhost:8000/default?sslmode=disable&session_token=enable";
     let client = Client::new(dsn.to_string());
     let conn = client.get_conn().await.unwrap();
 
-    let n= conn.exec("alter user u1 identified by 'p2' ").await.unwrap();
+    let n = conn
+        .exec("alter user u1 identified by 'p2' ")
+        .await
+        .unwrap();
     assert_eq!(n, 0);
 
-    let row= conn.query_row("select 1").await.unwrap();
+    let row = conn.query_row("select 1").await.unwrap();
     assert!(row.is_some());
     let row = row.unwrap();
     let (val,): (i64,) = row.try_into().unwrap();

--- a/driver/tests/driver/session.rs
+++ b/driver/tests/driver/session.rs
@@ -52,3 +52,33 @@ async fn set_timezone_with_dsn() {
     let (val,): (String,) = row.try_into().unwrap();
     assert_eq!(val, "Europe/London");
 }
+
+
+#[tokio::test]
+async fn change_password() {
+    let dsn = option_env!("TEST_DATABEND_DSN").unwrap_or(DEFAULT_DSN);
+    if dsn.starts_with("databend+flight://") {
+        // skip dsn variable test for flight
+        return;
+    }
+    let client = Client::new(dsn.to_string());
+    let conn = client.get_conn().await.unwrap();
+    let n= conn.exec("drop user if exists u1 ").await.unwrap();
+    assert_eq!(n, 0);
+    let n= conn.exec("create user u1 identified by 'p1' ").await.unwrap();
+    assert_eq!(n, 0);
+
+
+    let dsn="databend://u1:p1@localhost:8000/default?sslmode=disable&session_token=enable";
+    let client = Client::new(dsn.to_string());
+    let conn = client.get_conn().await.unwrap();
+
+    let n= conn.exec("alter user u1 identified by 'p2' ").await.unwrap();
+    assert_eq!(n, 0);
+
+    let row= conn.query_row("select 1").await.unwrap();
+    assert!(row.is_some());
+    let row = row.unwrap();
+    let (val,): (i64,) = row.try_into().unwrap();
+    assert_eq!(val, 1);
+}

--- a/driver/tests/driver/temp_table.rs
+++ b/driver/tests/driver/temp_table.rs
@@ -1,0 +1,52 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_driver::Client;
+use std::time::Duration;
+use tokio::time::sleep;
+
+use crate::common::DEFAULT_DSN;
+
+async fn test_temp_table(session_token_enabled: bool) {
+    let session_token = if session_token_enabled {
+        "enable"
+    } else {
+        "disable"
+    };
+    let dsn = option_env!("TEST_DATABEND_DSN").unwrap_or(DEFAULT_DSN);
+    let dsn = format!("{}&session_token={}", dsn, session_token);
+    let client = Client::new(dsn.to_string());
+    let conn = client.get_conn().await.unwrap();
+
+    let _ = conn.exec("create temp table t1 (a int)").await.unwrap();
+    let n = conn.exec("insert into t1 values (1),(2)").await.unwrap();
+    assert_eq!(n, 2);
+
+    let row = conn.query_row("select count(*) from t1").await.unwrap();
+    assert!(row.is_some());
+    let row = row.unwrap();
+    let (val,): (i64,) = row.try_into().unwrap();
+    assert_eq!(val, 2);
+    drop(conn);
+    sleep(Duration::from_millis(100)).await;
+}
+#[tokio::test]
+async fn test_temp_table_session_token() {
+    test_temp_table(true).await;
+}
+
+#[tokio::test]
+async fn test_temp_table_password() {
+    test_temp_table(false).await;
+}

--- a/driver/tests/driver/temp_table.rs
+++ b/driver/tests/driver/temp_table.rs
@@ -29,6 +29,12 @@ async fn test_temp_table(session_token_enabled: bool) {
     let client = Client::new(dsn.to_string());
     let conn = client.get_conn().await.unwrap();
 
+    let row = conn.query_row("select version()").await.unwrap();
+    assert!(row.is_some());
+    let row = row.unwrap();
+    let (val,): (String,) = row.try_into().unwrap();
+    println!("version = {}", val);
+
     let _ = conn.exec("create temp table t1 (a int)").await.unwrap();
     let n = conn.exec("insert into t1 values (1),(2)").await.unwrap();
     assert_eq!(n, 2);

--- a/driver/tests/driver/temp_table.rs
+++ b/driver/tests/driver/temp_table.rs
@@ -19,6 +19,11 @@ use tokio::time::sleep;
 use crate::common::DEFAULT_DSN;
 
 async fn test_temp_table(session_token_enabled: bool) {
+    let dsn = option_env!("TEST_DATABEND_DSN").unwrap_or(DEFAULT_DSN);
+    if dsn.starts_with("databend+flight://") {
+        return;
+    }
+
     let session_token = if session_token_enabled {
         "enable"
     } else {

--- a/sql/src/cursor_ext/cursor_read_bytes_ext.rs
+++ b/sql/src/cursor_ext/cursor_read_bytes_ext.rs
@@ -86,8 +86,8 @@ where
                 if available.is_empty() {
                     return 0;
                 }
-                for (index, byt) in available.iter().enumerate() {
-                    if !f(*byt) {
+                for (index, byte) in available.iter().enumerate() {
+                    if !f(*byte) {
                         self.consume(index);
                         return index;
                     }

--- a/sql/src/schema.rs
+++ b/sql/src/schema.rs
@@ -333,7 +333,9 @@ impl TryFrom<&Arc<ArrowField>> for Field {
                 ArrowDataType::Binary
                 | ArrowDataType::LargeBinary
                 | ArrowDataType::FixedSizeBinary(_) => DataType::Binary,
-                ArrowDataType::Utf8 | ArrowDataType::LargeUtf8 => DataType::String,
+                ArrowDataType::Utf8 | ArrowDataType::LargeUtf8 | ArrowDataType::Utf8View => {
+                    DataType::String
+                }
                 ArrowDataType::Timestamp(_, _) => DataType::Timestamp,
                 ArrowDataType::Date32 => DataType::Date,
                 ArrowDataType::Decimal128(p, s) => {

--- a/sql/src/value.rs
+++ b/sql/src/value.rs
@@ -30,6 +30,7 @@ use crate::{
     schema::{DecimalDataType, DecimalSize},
 };
 
+use arrow_array::StringViewArray;
 use geozero::wkb::FromWkb;
 use geozero::wkb::WkbDialect;
 use geozero::wkt::Ewkt;
@@ -402,7 +403,10 @@ impl TryFrom<(&ArrowField, &Arc<dyn ArrowArray>, usize)> for Value {
                 Some(array) => Ok(Value::String(array.value(seq).to_string())),
                 None => Err(ConvertError::new("large string", format!("{:?}", array)).into()),
             },
-
+            ArrowDataType::Utf8View => match array.as_any().downcast_ref::<StringViewArray>() {
+                Some(array) => Ok(Value::String(array.value(seq).to_string())),
+                None => Err(ConvertError::new("string view", format!("{:?}", array)).into()),
+            },
             // we only support timestamp in microsecond in databend
             ArrowDataType::Timestamp(unit, tz) => {
                 match array.as_any().downcast_ref::<TimestampMicrosecondArray>() {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,6 +7,7 @@ prepare:
 
 up: prepare
 	docker compose up --quiet-pull -d databend --wait
+	curl  -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d '{"sql": "select version()",  "pagination": { "wait_time_secs": 10}}'
 
 start: up
 

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     volumes:
       - ./data:/data
   databend:
-    image: docker.io/datafuselabs/databend
+    image: docker.io/datafuselabs/databend:nightly
     environment:
       - QUERY_STORAGE_TYPE=s3
       - QUERY_DATABEND_ENTERPRISE_LICENSE


### PR DESCRIPTION
feat:

1.  try to access `/v1/session/login`  to get session token and refresh token when init APIClient. it got 404,  do not use session token in the following request
3. uses session token when sending and polling query. it session token expired, renew token and retry
   4.  upload_stage accept a  Reader, so it can not retry,  check for expired and renew before request.
5. call `/v1/session/logout` when drop  APIClient 
6. support cookie to carry session id with each request, and even if session_token is not used.
4. DSN add param `session_token=enable|disable`, disable by default now,  may changed to enable by default after stable
5. DSN add param `login=enable|disable`, enabled by default, so user can choose to disable if only one query in session
6. after this pr, temp table is available, require databend server version >= 1.2.655 , but since heartbeat is not implemented yet, temp table will be cleaned up after session is idle for 4 hours, it is recommended to drop temp table after use, vacuum is used incase of forget or fail to drop it   


fix:

1. fix auth header when retry request. https://github.com/datafuselabs/bendsql/issues/477
3. no sleep when retry fro start query

refactors: 
1.  reclassify Errors and add Error::WithContext
4. unify retry policy
1.  use parking_lock instead of tokio lock 
2. make reading local jwt token file sync, so building request is sync

others:

allow license Unicode-3.0