### PR TITLE
chore: if return databend-query err should exit client

### DIFF
--- a/cli/src/session.rs
+++ b/cli/src/session.rs
@@ -115,11 +115,20 @@ impl Session {
                         databend_driver::Error::Arrow(arrow::error::ArrowError::IpcError(
                             ref ipc_err,
                         )) => {
-                            if ipc_err.contains("Unauthenticated") {
+                            if ipc_err.contains("Unauthenticated")
+                                || ipc_err.contains("Connection refused")
+                            {
                                 return Err(err.into());
                             }
                         }
-                        _ => return Err(err.into()),
+                        databend_driver::Error::Api(databend_client::error::Error::Request(
+                            ref resp_err,
+                        )) => {
+                            if resp_err.contains("error sending request for url") {
+                                return Err(err.into());
+                            }
+                        }
+                        _ => {}
                     }
                     "".to_string()
                 }

--- a/cli/src/session.rs
+++ b/cli/src/session.rs
@@ -119,7 +119,7 @@ impl Session {
                                 return Err(err.into());
                             }
                         }
-                        _ => {}
+                        _ => return Err(err.into()),
                     }
                     "".to_string()
                 }


### PR DESCRIPTION
Test:

in main branch:

If databend-query not start, bendsql not exit.

```shell
➜  bendsql git:(main) cargo build --bin bendsql && ./target/debug/bendsql --query='select 1'
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.12s
Error: APIError: RequestError: error sending request for url (http://localhost:8000/v1/query)
➜  bendsql git:(main) cargo build --bin bendsql && ./target/debug/bendsql                   
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.13s
Welcome to BendSQL 0.22.2-b6f550d(2024-10-30T03:05:49.669884189Z).
Connecting to localhost:8000 as user root.
Connected to 
Started web server at 127.0.0.1:8080

:) select 1;
error: APIError: RequestError: error sending request for url (http://localhost:8000/v1/query)

```