### PR TITLE
fix: fmt of error.

### DIFF
--- a/core/src/error_code.rs
+++ b/core/src/error_code.rs
@@ -38,12 +38,11 @@ pub struct ResponseWithErrorCode {
 
 impl Display for ErrorCode {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "[{}]{}.{}",
-            self.code,
-            self.message,
-            self.detail.clone().unwrap_or("".to_string())
-        )
+        match &self.detail {
+            Some(d) if !d.is_empty() => {
+                write!(f, "[{}]{}\n{}", self.code, self.message, d)
+            }
+            _ => write!(f, "[{}]{}", self.code, self.message,),
+        }
     }
 }


### PR DESCRIPTION
the message string itself contains a `\n` at the end， so the '.'  occupies a line by itself.