### PR TITLE
refactor: re-expose scheme from client

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -241,6 +241,10 @@ impl APIClient {
         self.port
     }
 
+    pub fn scheme(&self) -> &str {
+        self.scheme.as_str()
+    }
+
     async fn build_client(&mut self, name: Option<String>) -> Result<()> {
         let ua = match name {
             Some(n) => n,


### PR DESCRIPTION
3eb745e72c5b53bee28c2f6de4a7f208e0dfa795 made many client fields private. It exposed methods to get the port and host, but not the scheme. We are depending on the ability to fetch the scheme in `vectordotdev/vector` and so are currently [blocked from upgrading](https://github.com/vectordotdev/vector/pull/22027).

cc/ @everpcpc