### PR TITLE
fix: Fix: Correct sign extension handling in months_days_micros struct

### DIFF
--- a/sql/src/value.rs
+++ b/sql/src/value.rs
@@ -1876,8 +1876,10 @@ impl months_days_micros {
     /// A new [`months_days_micros`].
     pub fn new(months: i32, days: i32, microseconds: i64) -> Self {
         let months_bits = (months as i128) << 96;
-        let days_bits = (days as i128) << 64;
-        let micros_bits = microseconds as i128;
+        // converting to u32 before i128 ensures we’re working with the raw, unsigned bit pattern of the i32 value,
+        // preventing unwanted sign extension when that value is later used within the i128.
+        let days_bits = ((days as u32) as i128) << 64;
+        let micros_bits = (microseconds as u64) as i128;
 
         Self(months_bits | days_bits | micros_bits)
     }


### PR DESCRIPTION
Summary:

The MonthsDaysMicros struct’s new method incorrectly handled negative days and microseconds values, leading to incorrect bitwise representation and extraction. This PR addresses these issues by:

Casting days to u32 before casting to i128 to prevent sign extension. Casting microseconds to u64 before casting to i128 to prevent sign extension.