### PR TITLE
chore: enable duckdb crate  by arch

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,7 +10,10 @@ license = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(all(target_arch = "x86_64", target_os = "linux"))'.dependencies]
+duckdb = { version = "0.10.2", features = ["bundled"]}
+
+[target.'cfg(all(target_arch = "aarch64", target_os = "macos"))'.dependencies]
 duckdb = { version = "0.10.2", features = ["bundled"]}
 
 [dependencies]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,6 +10,9 @@ license = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
 
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+duckdb = { version = "0.10.2", features = ["bundled"]}
+
 [dependencies]
 chrono = { workspace = true }
 databend-client = { workspace = true }
@@ -26,7 +29,6 @@ comfy-table = "7.1"
 csv = "1.3"
 ctrlc = { version = "3.2.3", features = ["termination"] }
 databend-common-ast = "0.2.1"
-duckdb = { version = "0.10.2", features = ["bundled"] }
 fern = { version = "0.6", features = ["colored"] }
 indicatif = "0.17"
 log = "0.4"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -155,7 +155,7 @@ impl Settings {
         self.expand = cfg
             .expand
             .map(|expand| expand.as_str().into())
-            .unwrap_or_else(|| self.expand.clone());
+            .unwrap_or_else(|| self.expand);
         self.replace_newline = cfg.replace_newline.unwrap_or(self.replace_newline);
         self.max_width = cfg.max_width.unwrap_or(self.max_width);
         self.max_col_width = cfg.max_col_width.unwrap_or(self.max_col_width);

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -47,7 +47,7 @@ pub struct SettingsConfig {
     pub max_width: Option<usize>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Copy)]
 pub enum ExpandMode {
     On,
     Off,

--- a/cli/src/gendata.rs
+++ b/cli/src/gendata.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 use crate::{ast::GenType, session::Session};
 use anyhow::anyhow;
 use anyhow::Result;

--- a/cli/src/gendata.rs
+++ b/cli/src/gendata.rs
@@ -24,7 +24,10 @@ use databend_driver::RowStatsIterator;
 use databend_driver::RowWithStats;
 use databend_driver::Schema;
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(
+    all(target_arch = "x86_64", target_os = "linux"),
+    all(target_arch = "aarch64", target_os = "macos")
+))]
 impl Session {
     pub(crate) async fn gendata(
         &self,
@@ -36,7 +39,10 @@ impl Session {
     }
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(
+    all(target_arch = "x86_64", target_os = "linux"),
+    all(target_arch = "aarch64", target_os = "macos")
+))]
 impl Session {
     pub(crate) async fn gendata(
         &self,

--- a/cli/src/gendata.rs
+++ b/cli/src/gendata.rs
@@ -24,10 +24,10 @@ use databend_driver::RowStatsIterator;
 use databend_driver::RowWithStats;
 use databend_driver::Schema;
 
-#[cfg(not(
+#[cfg(not(any(
     all(target_arch = "x86_64", target_os = "linux"),
     all(target_arch = "aarch64", target_os = "macos")
-))]
+)))]
 impl Session {
     pub(crate) async fn gendata(
         &self,

--- a/cli/src/gendata.rs
+++ b/cli/src/gendata.rs
@@ -91,7 +91,7 @@ impl Session {
             let path = f.path();
 
             // Skip if the path is a directory or if it does not end with .parquet
-            if path.is_dir() || path.extension().map_or(true, |ext| ext != "parquet") {
+            if path.is_dir() || path.extension().is_none_or(|ext| ext != "parquet") {
                 continue;
             }
             let table_name = path.file_stem().unwrap().to_str().unwrap().to_string();


### PR DESCRIPTION
1.  enable duckdb crate only by 

```
#[cfg(any(
    all(target_arch = "x86_64", target_os = "linux"),
    all(target_arch = "aarch64", target_os = "macos")
))]
```
3.  support '\G' suffix in bendsql repl mode like MySQL