### PR TITLE
fix: re-format the query-id

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -339,7 +339,7 @@ impl APIClient {
     }
 
     fn gen_query_id(&self) -> String {
-        uuid::Uuid::new_v4().to_string()
+        uuid::Uuid::new_v4().to_string().replace("-", "")
     }
 
     async fn handle_session(&self, session: &Option<SessionState>) {


### PR DESCRIPTION
Because the query-id format in databend query will be changed from a-b-c-d to abcd in this https://github.com/databendlabs/databend/pull/17947, so the driver need to do the same.
We change the code where generate query-id by replacing the `-` in query-id.

This pr should be merged after the databend query make compatibility.