### PR TITLE
feat: support Option<T> as sql params

### DIFF
--- a/bindings/python/src/utils.rs
+++ b/bindings/python/src/utils.rs
@@ -73,6 +73,9 @@ pub(crate) fn to_sql_params(v: Option<Bound<PyAny>>) -> Params {
 }
 
 fn to_sql_string(v: Bound<PyAny>) -> PyResult<String> {
+    if v.is_none() {
+        return Ok("NULL".to_string());
+    }
     match v.downcast::<PyAny>() {
         Ok(v) => {
             if let Ok(v) = v.extract::<String>() {

--- a/bindings/python/src/utils.rs
+++ b/bindings/python/src/utils.rs
@@ -39,7 +39,6 @@ where
     py.allow_threads(|| RUNTIME.block_on(f))
 }
 
-//  params: Option<Bound<'p, PyAny>>
 pub(crate) fn to_sql_params(v: Option<Bound<PyAny>>) -> Params {
     match v {
         Some(v) => {

--- a/bindings/python/tests/cursor/steps/binding.py
+++ b/bindings/python/tests/cursor/steps/binding.py
@@ -50,7 +50,7 @@ def _(context):
 
 @then("Select params binding")
 def _(context):
-    context.cursor.execute("SELECT ?, ?, ?, ?", (3, False, 4, "55", None))
+    context.cursor.execute("SELECT ?, ?, ?, ?, ?", (3, False, 4, "55", None))
     row = context.cursor.fetchone()
     assert row.values() == (3, False, 4, "55", None), f"output: {row.values()}"
 
@@ -67,7 +67,7 @@ def _(context):
     assert row.values() == (4,), f"output: {row.values()}"
 
     # Test with positional parameters again
-    context.cursor.execute("SELECT ?, ?, ?, ?", (3, False, 4, "55", None))
+    context.cursor.execute("SELECT ?, ?, ?, ?, ?", (3, False, 4, "55", None))
     row = context.cursor.fetchone()
     assert row.values() == (3, False, 4, "55", None), f"output: {row.values()}"
 

--- a/bindings/python/tests/cursor/steps/binding.py
+++ b/bindings/python/tests/cursor/steps/binding.py
@@ -50,16 +50,17 @@ def _(context):
 
 @then("Select params binding")
 def _(context):
-    context.cursor.execute("SELECT ?, ?, ?, ?", (3, False, 4, "55"))
+    context.cursor.execute("SELECT ?, ?, ?, ?", (3, False, 4, "55", None))
     row = context.cursor.fetchone()
-    assert row.values() == (3, False, 4, "55"), f"output: {row.values()}"
+    assert row.values() == (3, False, 4, "55", None), f"output: {row.values()}"
 
     # Test with named parameters
     context.cursor.execute(
-        "SELECT :a, :b, :c, :d", {"a": 3, "b": False, "c": 4, "d": "55"}
+        "SELECT :a, :b, :c, :d, :e",
+        {"a": 3, "b": False, "c": 4, "d": "55", "e": None},
     )
     row = context.cursor.fetchone()
-    assert row.values() == (3, False, 4, "55"), f"output: {row.values()}"
+    assert row.values() == (3, False, 4, "55", None), f"output: {row.values()}"
 
     context.cursor.execute("SELECT ?", 4)
     row = context.cursor.fetchone()

--- a/bindings/python/tests/cursor/steps/binding.py
+++ b/bindings/python/tests/cursor/steps/binding.py
@@ -66,14 +66,9 @@ def _(context):
     assert row.values() == (4,), f"output: {row.values()}"
 
     # Test with positional parameters again
-    context.cursor.execute("SELECT ?, ?, ?, ?", (3, False, 4, "55"))
+    context.cursor.execute("SELECT ?, ?, ?, ?", (3, False, 4, "55", None))
     row = context.cursor.fetchone()
-    assert row.values() == (3, False, 4, "55"), f"output: {row.values()}"
-
-    # Test with None
-    context.cursor.execute("SELECT ?", None)
-    row = context.cursor.fetchone()
-    assert row.values() == (None,), f"output: {row.values()}"
+    assert row.values() == (3, False, 4, "55", None), f"output: {row.values()}"
 
 
 @then("Select string {input} should be equal to {output}")

--- a/bindings/python/tests/cursor/steps/binding.py
+++ b/bindings/python/tests/cursor/steps/binding.py
@@ -70,6 +70,11 @@ def _(context):
     row = context.cursor.fetchone()
     assert row.values() == (3, False, 4, "55"), f"output: {row.values()}"
 
+    # Test with None
+    context.cursor.execute("SELECT ?", None)
+    row = context.cursor.fetchone()
+    assert row.values() == (None,), f"output: {row.values()}"
+
 
 @then("Select string {input} should be equal to {output}")
 def _(context, input, output):

--- a/bindings/python/tests/cursor/steps/binding.py
+++ b/bindings/python/tests/cursor/steps/binding.py
@@ -171,7 +171,7 @@ def _(context):
     assert ret == expected, f"ret: {ret}"
 
     desc = context.cursor.description
-    assert desc != None
+    assert desc is not None
 
     # fetchmany
     context.cursor.execute("SELECT * FROM test")

--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -743,11 +743,7 @@ fn format_table_style(value: &Value, max_col_width: usize, replace_newline: bool
         value
     };
     if value.len() + 3 > max_col_width {
-        let element_size = if max_col_width >= 6 {
-            max_col_width - 6
-        } else {
-            0
-        };
+        let element_size = max_col_width.saturating_sub(6);
         value = String::from_utf8(
             value
                 .graphemes(true)

--- a/driver/src/params.rs
+++ b/driver/src/params.rs
@@ -129,6 +129,13 @@ impl Param for &str {
     }
 }
 
+// Impl Param for None
+impl Param for () {
+    fn as_sql_string(&self) -> String {
+        "NULL".to_string()
+    }
+}
+
 impl<T> Param for Option<T>
 where
     T: Param,
@@ -182,7 +189,7 @@ impl Param for serde_json::Value {
 macro_rules! params {
     // Handle named parameters
     () => {
-	    $crate::Params::default()
+        $crate::Params::default()
     };
     ($($key:ident => $value:expr),* $(,)?) => {
         $crate::Params::NamedParams({
@@ -316,6 +323,15 @@ mod tests {
                 Params::QuestionParams(vec) => {
                     assert_eq!(vec, vec!["1", "'44'", "2", "3", "'55'", "'66'"]);
                 }
+                _ => panic!("Expected QuestionParams"),
+            }
+        }
+
+        // Test Option<T>
+        {
+            let params: Params = (Some(1), None::<()>, Some("44"), None::<()>).into();
+            match params {
+                Params::QuestionParams(vec) => assert_eq!(vec, vec!["1", "NULL", "'44'", "NULL"]),
                 _ => panic!("Expected QuestionParams"),
             }
         }

--- a/driver/src/params.rs
+++ b/driver/src/params.rs
@@ -129,6 +129,18 @@ impl Param for &str {
     }
 }
 
+impl<T> Param for Option<T>
+where
+    T: Param,
+{
+    fn as_sql_string(&self) -> String {
+        match self {
+            Some(s) => s.as_sql_string(),
+            None => "NULL".to_string(),
+        }
+    }
+}
+
 impl Param for serde_json::Value {
     fn as_sql_string(&self) -> String {
         match self {


### PR DESCRIPTION
## Pull Request Overview

This PR adds support for using Option<T> as SQL parameters by implementing the Param trait for both () and Option<T>. It also updates tests in both Rust and Python bindings to validate the proper handling of None/NULL values.
- Adds impl Param for () and Option<T> in driver/src/params.rs
- Updates tests in Python bindings for correct handling of NULL values
- Adjusts Python code to use best practices when checking for None
