### PR TITLE
fix: display query parse error

### DIFF
--- a/cli/src/session.rs
+++ b/cli/src/session.rs
@@ -510,9 +510,10 @@ impl Session {
                         }
                         previous_token_backslash = matches!(token.kind, TokenKind::Backslash);
                     }
-                    Err(_) => {
+                    Err(e) => {
                         // ignore current query if have invalid token.
                         is_valid = false;
+                        eprintln!("Parser '{}' failed\nwith error '{}'", line, e);
                         continue;
                     }
                 }


### PR DESCRIPTION
```
root@localhost:8000/default/default> explain select * from default.t1 where a in （'x'); 
Parser 'explain select * from default.t1 where a in （'x');' failed 
with error 'unable to recognize the rest tokens'
```