### PR TITLE
refactor: polish file load APIs.

### DIFF
--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -172,7 +172,7 @@ impl Connection {
     pub async fn stream_load(&self, sql: String, data: Vec<Vec<&str>>) -> Result<ServerStats> {
         let ss = self
             .inner
-            .stream_load(&sql, data, LoadMethod::Streaming)
+            .stream_load(&sql, data, LoadMethod::Stage)
             .await
             .map_err(format_napi_error)?;
         Ok(ServerStats(ss))

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -17,7 +17,6 @@ chrono = { workspace = true }
 databend-driver = { workspace = true, features = ["rustls", "flight-sql"] }
 tokio-stream = { workspace = true }
 
-csv = "1.3"
 ctor = "0.2"
 once_cell = "1.21"
 pyo3 = { version = "0.24.2", features = ["abi3-py37", "chrono"] }

--- a/bindings/python/src/asyncio.rs
+++ b/bindings/python/src/asyncio.rs
@@ -173,7 +173,7 @@ impl AsyncDatabendConnection {
                 .map(|v| v.iter().map(|s| s.as_ref()).collect())
                 .collect();
             let ss = this
-                .stream_load(&sql, data, LoadMethod::Streaming)
+                .stream_load(&sql, data, LoadMethod::Stage)
                 .await
                 .map_err(DriverError::new)?;
             Ok(ServerStats::new(ss))

--- a/bindings/python/src/blocking.rs
+++ b/bindings/python/src/blocking.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use crate::types::{ConnectionInfo, DriverError, Row, RowIterator, ServerStats, VERSION};
 use crate::utils::{options_as_ref, to_sql_params, wait_for_future};
 use databend_driver::{LoadMethod, SchemaRef};
-use pyo3::exceptions::{PyAttributeError, PyException, PyStopIteration};
+use pyo3::exceptions::{PyAttributeError, PyStopIteration};
 use pyo3::types::{PyList, PyTuple};
 use pyo3::{prelude::*, IntoPyObjectExt};
 use tokio::sync::Mutex;
@@ -327,12 +327,13 @@ impl BlockingDatabendCursor {
         let conn = self.conn.clone();
         if let Some(param) = seq_of_parameters.first() {
             if param.downcast::<PyList>().is_ok() || param.downcast::<PyTuple>().is_ok() {
-                let bytes = format_csv(seq_of_parameters)?;
-                let size = bytes.len() as u64;
-                let sql = format!("{sql} from @_databend_load file_format=(type=csv)");
-                let reader = Box::new(std::io::Cursor::new(bytes));
+                let strings = to_csv_strings(seq_of_parameters)?;
+                let strs = strings
+                    .iter()
+                    .map(|v| v.iter().map(|s| s.as_str()).collect::<Vec<_>>())
+                    .collect::<Vec<_>>();
                 let stats = wait_for_future(py, async move {
-                    conn.load_data(&sql, reader, size, LoadMethod::Streaming)
+                    conn.stream_load(&sql, strs, LoadMethod::Stage)
                         .await
                         .map_err(DriverError::new)
                 })?;
@@ -420,25 +421,19 @@ impl BlockingDatabendCursor {
     }
 }
 
-fn format_csv(parameters: Vec<Bound<'_, PyAny>>) -> PyResult<Vec<u8>> {
-    let mut wtr = csv::WriterBuilder::new().from_writer(vec![]);
+fn to_csv_strings(parameters: Vec<Bound<'_, PyAny>>) -> PyResult<Vec<Vec<String>>> {
+    let mut rows = Vec::with_capacity(parameters.len());
     for row in parameters {
         let iter = row.try_iter()?;
-        let data = iter
+        let row = iter
             .map(|v| match v {
                 Ok(v) => to_csv_field(v),
                 Err(e) => Err(e),
             })
             .collect::<Result<Vec<_>, _>>()?;
-        wtr.write_record(data)
-            .map_err(|e| PyException::new_err(e.to_string()))
-            .unwrap();
+        rows.push(row);
     }
-    let bytes = wtr
-        .into_inner()
-        .map_err(|e| PyException::new_err(e.to_string()))
-        .unwrap();
-    Ok(bytes)
+    Ok(rows)
 }
 
 fn to_csv_field(v: Bound<PyAny>) -> PyResult<String> {

--- a/bindings/python/src/blocking.rs
+++ b/bindings/python/src/blocking.rs
@@ -157,7 +157,7 @@ impl BlockingDatabendConnection {
                 .iter()
                 .map(|v| v.iter().map(|s| s.as_ref()).collect())
                 .collect();
-            this.stream_load(&sql, data, LoadMethod::Streaming)
+            this.stream_load(&sql, data, LoadMethod::Stage)
                 .await
                 .map_err(DriverError::new)
         })?;

--- a/bindings/python/tests/asyncio/steps/binding.py
+++ b/bindings/python/tests/asyncio/steps/binding.py
@@ -198,13 +198,13 @@ async def test_load_file(context, load_method):
     assert ret == expected, f"{load_method} ret: {ret}"
 
 
-@then("Load file with stage and Select should be equal")
+@then("Load file with Stage and Select should be equal")
 @async_run_until_complete
 async def _(context):
     await test_load_file(context, "stage")
 
 
-@then("Load file with streaming and Select should be equal")
+@then("Load file with Streaming and Select should be equal")
 @async_run_until_complete
 async def _(context):
     await test_load_file(context, "streaming")

--- a/bindings/python/tests/blocking/steps/binding.py
+++ b/bindings/python/tests/blocking/steps/binding.py
@@ -87,7 +87,7 @@ async def _(context):
     assert row.values() == (timedelta(microseconds=1),), f"Interval: {row.values()}"
 
     # Decimal
-    row = context.conn.query_row("SELECT 15.7563::Decimal(?,?), 2.0+3.0", params=[8, 4])
+    row = context.conn.query_row("SELECT 15.7563::Decimal(8,4), 2.0+3.0", params=[8, 4])
     assert row.values() == (
         Decimal("15.7563"),
         Decimal("5.0"),

--- a/bindings/python/tests/cursor/steps/binding.py
+++ b/bindings/python/tests/cursor/steps/binding.py
@@ -109,7 +109,7 @@ async def _(context):
     # Array
     context.cursor.execute("select [10::Decimal(15,2), 1.1+2.3]")
     row = context.cursor.fetchone()
-    expected = [Decimal("10.00"), Decimal("3.40")]
+    expected = ([Decimal("10.00"), Decimal("3.40")],)
     assert row.values() == expected, f"Array: {row.values()}"
 
     # Map

--- a/bindings/python/tests/cursor/steps/binding.py
+++ b/bindings/python/tests/cursor/steps/binding.py
@@ -109,13 +109,13 @@ async def _(context):
     # Array
     context.cursor.execute("select [10::Decimal(15,2), 1.1+2.3]")
     row = context.cursor.fetchone()
-    expected = ([Decimal("10.00"), Decimal("3.40")],)
+    expected = ([Decimal("10.00"), Decimal("3.40")], )
     assert row.values() == expected, f"Array: {row.values()}"
 
     # Map
     context.cursor.execute("select {'xx':to_date('2020-01-01')}")
     row = context.cursor.fetchone()
-    expected = {"xx": date(2020, 1, 1)}
+    expected = ({"xx": date(2020, 1, 1)}, )
     assert row.values() == expected, f"Map: {row.values()}"
 
     # Tuple

--- a/bindings/python/tests/cursor/steps/binding.py
+++ b/bindings/python/tests/cursor/steps/binding.py
@@ -109,22 +109,24 @@ async def _(context):
     # Array
     context.cursor.execute("select [10::Decimal(15,2), 1.1+2.3]")
     row = context.cursor.fetchone()
-    expected = ([Decimal("10.00"), Decimal("3.40")], )
+    expected = ([Decimal("10.00"), Decimal("3.40")],)
     assert row.values() == expected, f"Array: {row.values()}"
 
     # Map
     context.cursor.execute("select {'xx':to_date('2020-01-01')}")
     row = context.cursor.fetchone()
-    expected = ({"xx": date(2020, 1, 1)}, )
+    expected = ({"xx": date(2020, 1, 1)},)
     assert row.values() == expected, f"Map: {row.values()}"
 
     # Tuple
     context.cursor.execute("select (10, '20', to_datetime('2024-04-16 12:34:56.789'))")
     row = context.cursor.fetchone()
     expected = (
-        10,
-        "20",
-        datetime(2024, 4, 16, 12, 34, 56, 789000),
+        (
+            10,
+            "20",
+            datetime(2024, 4, 16, 12, 34, 56, 789000),
+        ),
     )
     assert row.values() == expected, f"Tuple: {row.values()}"
 

--- a/driver/src/rest_api.rs
+++ b/driver/src/rest_api.rs
@@ -242,7 +242,7 @@ impl IConnection for RestAPIConnection {
         data: Vec<Vec<&str>>,
         method: LoadMethod,
     ) -> Result<ServerStats> {
-        info!("stream load: {}, length: {:?}", sql, data.len());
+        info!("stream load: {}; rows: {:?}", sql, data.len());
         let mut wtr = csv::WriterBuilder::new().from_writer(vec![]);
         for row in data {
             wtr.write_record(row)

--- a/sql/src/value.rs
+++ b/sql/src/value.rs
@@ -1979,3 +1979,14 @@ impl months_days_micros {
         (self.0 & MICROS_MASK) as i64
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_string_basic_positive() {
+        let interval = Interval::from_string("0:00:00.000001").unwrap();
+        assert_eq!(interval.micros, 1);
+    }
+}

--- a/sql/src/value.rs
+++ b/sql/src/value.rs
@@ -1342,8 +1342,8 @@ fn parse_number(bytes: &[u8]) -> Result<(i64, i64, usize)> {
             }
         }
         if time_bytes.len() > time_pos {
-            let (seconds, nanos, next_pos) = parse_time_part_with_nanos(&time_bytes[time_pos..])?;
-            total_micros += seconds * MICROS_PER_SEC + nanos;
+            let (seconds, micros, next_pos) = parse_time_part_with_macros(&time_bytes[time_pos..])?;
+            total_micros += seconds * MICROS_PER_SEC + micros;
             time_pos += next_pos;
         }
         return Ok((total_micros, 0, pos + time_pos));
@@ -1369,7 +1369,7 @@ fn parse_time_part(bytes: &[u8]) -> Result<(i64, i64, usize)> {
     Ok((number, 0, pos))
 }
 
-fn parse_time_part_with_nanos(bytes: &[u8]) -> Result<(i64, i64, usize)> {
+fn parse_time_part_with_macros(bytes: &[u8]) -> Result<(i64, i64, usize)> {
     let mut number: i64 = 0;
     let mut fraction: i64 = 0;
     let mut pos = 0;
@@ -1384,7 +1384,7 @@ fn parse_time_part_with_nanos(bytes: &[u8]) -> Result<(i64, i64, usize)> {
 
     if pos < bytes.len() && bytes[pos] == b'.' {
         pos += 1;
-        let mut mult: i64 = 100000000;
+        let mut mult: i64 = 100000;
         while pos < bytes.len() && bytes[pos].is_ascii_digit() {
             if mult > 0 {
                 fraction += (bytes[pos] - b'0') as i64 * mult;


### PR DESCRIPTION
- use LoadMethod::Stage by default,  Streaming Load need add session info
- executemany  reuse API stream_load instead of formating csv itself
- load_file tolerant old SQL without placeholder for fewer breaking change.
- fix interval parsing of python bindings
