### PR TITLE
feat: modify max_width

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,23 +150,23 @@ prompt = ":) "
 
 - Settings section
 
-| Parameter            | Description                                                                         |
-| -------------------- | ----------------------------------------------------------------------------------- |
-| `display_pretty_sql` | Whether to display SQL queries in a formatted way.                                  |
-| `prompt`             | The prompt to display before asking for input.                                      |
-| `progress_color`     | The color to use for the progress bar.                                              |
-| `show_progress`      | Whether to show a progress bar when executing queries.                              |
-| `show_stats`         | Whether to show statistics after executing queries.                                 |
-| `no_auto_complete`   | Whether to disable loading tables and fields for auto-completion on startup.        |
-| `max_display_rows`   | The maximum number of rows to display in table output format.                       |
-| `max_width`          | Limit display render box max width, 0 means default to the size of the terminal.    |
-| `max_col_width`      | Limit display render each column max width, smaller than 3 means disable the limit. |
-| `output_format`      | The output format to use.                                                           |
-| `expand`             | Expand table format display, default auto, could be on/off/auto.                    |
-| `time`               | Whether to show the time elapsed when executing queries.                            |
-| `multi_line`         | Whether to allow multi-line input.                                                  |
-| `quote_string`       | Whether to quote string values in table output format, default false.               |
-| `sql_delimiter`      | SQL delimiter, default `;`.                                                         |
+| Parameter            | Description                                                                                                         |
+| -------------------- |---------------------------------------------------------------------------------------------------------------------|
+| `display_pretty_sql` | Whether to display SQL queries in a formatted way.                                                                  |
+| `prompt`             | The prompt to display before asking for input.                                                                      |
+| `progress_color`     | The color to use for the progress bar.                                                                              |
+| `show_progress`      | Whether to show a progress bar when executing queries.                                                              |
+| `show_stats`         | Whether to show statistics after executing queries.                                                                 |
+| `no_auto_complete`   | Whether to disable loading tables and fields for auto-completion on startup.                                        |
+| `max_display_rows`   | The maximum number of rows to display in table output format.                                                       |
+| `max_width`          | Limit display render box max width, 0 means default to the size of the terminal. 65535 means no limit for max_width |
+| `max_col_width`      | Limit display render each column max width, smaller than 3 means disable the limit.                                 |
+| `output_format`      | The output format to use.                                                                                           |
+| `expand`             | Expand table format display, default auto, could be on/off/auto.                                                    |
+| `time`               | Whether to show the time elapsed when executing queries.                                                            |
+| `multi_line`         | Whether to allow multi-line input.                                                                                  |
+| `quote_string`       | Whether to quote string values in table output format, default false.                                               |
+| `sql_delimiter`      | SQL delimiter, default `;`.                                                                                         |
 
 ## Commands in REPL
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -290,7 +290,8 @@ impl Default for Settings {
             show_progress: false,
             max_display_rows: 1000,
             max_col_width: 1024 * 1024,
-            max_width: 1024 * 1024,
+            // Default width is terminal size
+            max_width: 0,
             show_stats: false,
             time: None,
             multi_line: true,

--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -526,7 +526,9 @@ fn create_table(
 
     let w = terminal_size();
     if max_width != 0 && max_width <= u16::MAX as usize {
-        if let Some((w, _)) = w {
+        if max_width == u16::MAX as usize {
+            table.set_content_arrangement(comfy_table::ContentArrangement::Disabled);
+        } else if let Some((w, _)) = w {
             let max_width = max_width.min(w.0 as usize);
             table.set_width(max_width as _);
         }


### PR DESCRIPTION
Limit display render box max width, 0 means default to the size of the terminal. 65535 means no limit for max_width. 0-65535 means the min with value of config and terminal size.