### PR TITLE
feat: change Field from class to object. 

### DIFF
--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -393,24 +393,21 @@ pub struct Schema(databend_driver::SchemaRef);
 impl Schema {
     #[napi]
     pub fn fields(&self) -> Vec<Field> {
-        self.0.fields().iter().map(|f| Field(f.clone())).collect()
+        self.0
+            .fields()
+            .iter()
+            .map(|f| Field {
+                name: f.name.clone(),
+                data_type: f.data_type.to_string().clone(),
+            })
+            .collect()
     }
 }
 
-#[napi]
-pub struct Field(databend_driver::Field);
-
-#[napi]
-impl Field {
-    #[napi(getter)]
-    pub fn name(&self) -> String {
-        self.0.name.to_string()
-    }
-
-    #[napi(getter)]
-    pub fn data_type(&self) -> String {
-        self.0.data_type.to_string()
-    }
+#[napi(object)]
+pub struct Field {
+    pub name: String,
+    pub data_type: String,
 }
 
 #[napi]

--- a/bindings/nodejs/tests/binding.js
+++ b/bindings/nodejs/tests/binding.js
@@ -203,6 +203,12 @@ Then("Select numbers should iterate all rows", async function () {
   // iter
   {
     let rows = await this.conn.queryIter("SELECT number FROM numbers(5)");
+
+    let schema = rows.schema();
+    const fields = schema.fields();
+    assert.equal(fields[0].name, "number");
+    assert.equal(fields[0].dataType, "UInt64");
+
     let ret = [];
     let row = await rows.next();
     while (row) {


### PR DESCRIPTION

otherwise, console.log(schema.fields()) shows an empty array, which is misleading,  although we can get fields in it.

Schema not  changed to avoid breaking function `.fields()`.

