### PR TITLE
fix(driver): support extended datetime ranges with chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ jsonb = { version = "0.5.6" }
 tokio-stream = "0.1"
 chrono = { version = "0.4.40", default-features = false, features = ["clock"] }
 chrono-tz = { version = "0.10.4" }
-jiff = { version = "0.2.10", features = ["tzdb-bundle-always"] }
 arrow = { version = "56" }
 arrow-array = { version = "56" }
 arrow-schema = { version = "56" }

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -316,19 +316,19 @@ impl ToNapiValue for Value<'_> {
             }
             databend_driver::Value::Timestamp(dt) => {
                 let mut js_date = std::ptr::null_mut();
-                let millis = dt.timestamp().as_millisecond() as f64;
+                let millis = dt.timestamp_millis() as f64;
                 check_status!(
                     unsafe { sys::napi_create_date(env, millis, &mut js_date) },
-                    "Failed to convert jiff timestamp into napi value",
+                    "Failed to convert timestamp into napi value",
                 )?;
                 Ok(js_date)
             }
             databend_driver::Value::TimestampTz(dt) => {
                 let mut js_date = std::ptr::null_mut();
-                let millis = dt.timestamp().as_millisecond() as f64;
+                let millis = dt.timestamp_millis() as f64;
                 check_status!(
                     unsafe { sys::napi_create_date(env, millis, &mut js_date) },
-                    "Failed to convert jiff timestamp into napi value",
+                    "Failed to convert timestamp_tz into napi value",
                 )?;
                 Ok(js_date)
             }

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -24,7 +24,7 @@ ctor = "0.2"
 env_logger = "0.11.8"
 http = "1.0"
 once_cell = "1.21"
-pyo3 = { version = "0.24.2", features = ["extension-module", "chrono", "jiff-02"] }
+pyo3 = { version = "0.24.2", features = ["extension-module", "chrono", "chrono-tz"] }
 pyo3-async-runtimes = { version = "0.24", features = ["tokio-runtime"] }
 tokio = "1.44"
 

--- a/bindings/python/src/types.rs
+++ b/bindings/python/src/types.rs
@@ -16,8 +16,6 @@ use std::sync::Arc;
 
 #[cfg(feature = "cp38")]
 use chrono::offset::Offset;
-#[cfg(feature = "cp38")]
-use chrono::FixedOffset;
 use chrono::{Duration, NaiveDate};
 use once_cell::sync::Lazy;
 use pyo3::exceptions::{PyAttributeError, PyException, PyStopAsyncIteration, PyStopIteration};
@@ -31,8 +29,6 @@ use tokio_stream::StreamExt;
 
 use crate::exceptions::map_error_to_exception;
 use crate::utils::wait_for_future;
-#[cfg(feature = "cp38")]
-use databend_driver::{self, zoned_to_chrono_datetime, zoned_to_chrono_fixed_offset};
 use databend_driver_core::value::GeoValue;
 
 pub static VERSION: Lazy<String> = Lazy::new(|| {
@@ -83,31 +79,14 @@ impl<'py> IntoPyObject<'py> for Value {
             databend_driver::Value::Timestamp(dt) => {
                 #[cfg(feature = "cp38")]
                 {
-                    let chrono_dt = zoned_to_chrono_datetime(&dt).map_err(|e| {
-                        PyException::new_err(format!("failed to convert timestamp: {e}"))
-                    })?;
-                    chrono_dt
-                        .with_timezone(&chrono_dt.offset().fix())
-                        .into_bound_py_any(py)?
+                    dt.with_timezone(&dt.offset().fix()).into_bound_py_any(py)?
                 }
                 #[cfg(not(feature = "cp38"))]
                 {
                     dt.into_bound_py_any(py)?
                 }
             }
-            databend_driver::Value::TimestampTz(t) => {
-                #[cfg(feature = "cp38")]
-                {
-                    let chrono_dt = zoned_to_chrono_fixed_offset(&t).map_err(|e| {
-                        PyException::new_err(format!("failed to convert timestamp_tz: {e}"))
-                    })?;
-                    chrono_dt.into_bound_py_any(py)?
-                }
-                #[cfg(not(feature = "cp38"))]
-                {
-                    t.into_bound_py_any(py)?
-                }
-            }
+            databend_driver::Value::TimestampTz(t) => t.into_bound_py_any(py)?,
             databend_driver::Value::Date(_) => {
                 let d = NaiveDate::try_from(self.0)
                     .map_err(|e| PyException::new_err(format!("failed to convert date: {e}")))?;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,7 +27,7 @@ arrow-schema = { workspace = true }
 bytes = "1.10.1"
 base64 = "0.22.1"
 cookie = "0.18.1"
-jiff = { workspace = true }
+chrono-tz = { workspace = true }
 log = { version = "0.4", features = ["kv"] }
 once_cell = "1.21"
 parking_lot = "0.12.3"

--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -14,14 +14,14 @@
 
 use crate::error::Result;
 use crate::Error;
-use jiff::tz::TimeZone;
+use chrono_tz::Tz;
 use serde::Deserialize;
 use std::str::FromStr;
 
 #[derive(Debug, Clone)]
 pub struct ResultFormatSettings {
     pub geometry_output_format: GeometryDataType,
-    pub timezone: TimeZone,
+    pub timezone: Tz,
     pub arrow_result_version: Option<i64>,
     pub binary_output_format: BinaryFormat,
 }
@@ -31,7 +31,7 @@ impl Default for ResultFormatSettings {
         Self {
             geometry_output_format: GeometryDataType::default(),
             binary_output_format: BinaryFormat::default(),
-            timezone: TimeZone::UTC,
+            timezone: Tz::UTC,
             arrow_result_version: None,
         }
     }
@@ -43,8 +43,8 @@ impl TryFrom<&Option<QueryResultFormatSettings>> for ResultFormatSettings {
     fn try_from(settings: &Option<QueryResultFormatSettings>) -> Result<Self> {
         let settings = settings.clone().unwrap_or_default();
         let timezone = match settings.timezone {
-            None => TimeZone::UTC,
-            Some(t) => TimeZone::get(&t).map_err(|e| Error::Decode(e.to_string()))?,
+            None => Tz::UTC,
+            Some(t) => t.parse::<Tz>().map_err(|e| Error::Decode(e.to_string()))?,
         };
 
         let geometry_output_format = match settings.geometry_output_format {
@@ -144,7 +144,7 @@ mod tests {
         assert_eq!(settings.geometry_output_format, GeometryDataType::WKT);
         assert_eq!(settings.arrow_result_version, Some(2));
         assert_eq!(settings.binary_output_format, BinaryFormat::Utf8);
-        assert_eq!(settings.timezone.iana_name(), Some("Asia/Shanghai"));
+        assert_eq!(settings.timezone, Tz::Asia__Shanghai);
     }
 
     #[test]
@@ -155,7 +155,7 @@ mod tests {
         assert_eq!(settings.geometry_output_format, GeometryDataType::default());
         assert_eq!(settings.arrow_result_version, None);
         assert_eq!(settings.binary_output_format, BinaryFormat::default());
-        assert_eq!(settings.timezone.iana_name(), Some("UTC"));
+        assert_eq!(settings.timezone, Tz::UTC);
     }
 
     #[test]

--- a/driver/README.md
+++ b/driver/README.md
@@ -178,31 +178,22 @@ let inserted = insert.end().await?;
 `Value::Timestamp` stores a `chrono::DateTime<chrono_tz::Tz>` in the session
 timezone, and `Value::TimestampTz` stores a `chrono::DateTime<chrono::FixedOffset>`
 with the offset returned by the server. Converting `TIMESTAMP` to
-`chrono::NaiveDateTime` continues to return the **UTC** datetime, not the local
-wall-clock time. Converting a `NaiveDateTime` into `Value` interprets it as UTC.
+`chrono::NaiveDateTime` returns the **UTC** datetime, not the local wall-clock
+time. Converting a `NaiveDateTime` into `Value` interprets it as UTC. Row
+conversion supports `DateTime<Tz>` and `DateTime<FixedOffset>` directly.
 
 Both HTTP and Arrow decoding preserve microseconds at the SQL timestamp bounds,
-including `9999-12-31 23:59:59.999999` UTC. A valid UTC instant may display in local
-year 10000 after timezone conversion. Arrow decoding no longer clamps timestamps
-to Jiff's smaller range. The driver's wider representation does not expand the
-server's accepted UTC timestamp range.
+including `9999-12-31 23:59:59.999999` UTC. A valid UTC instant may display in
+local year 10000 after timezone conversion; the driver's wider representation
+does not expand the server's accepted UTC timestamp range.
 
-**Rust API migration:** the timestamp variants and `ResultFormatSettings::timezone`
-now use Chrono types instead of Jiff. Use `format(...)` instead of `strftime(...)`,
-`timestamp_micros()` instead of `timestamp().as_microsecond()`, and `chrono_tz::Tz`
-for session timezones. The `zoned_to_chrono_datetime` and
-`zoned_to_chrono_fixed_offset` helpers have been removed: the values already are
-Chrono datetimes. Row conversion supports `DateTime<Tz>` and `DateTime<FixedOffset>`
-directly.
+HTTP timestamps carry no offset, so decoding resolves DST by taking the earlier
+instant in a fold and shifting forward by the offset change in a gap. Arrow
+timestamps identify the instant unambiguously.
 
-HTTP timestamps contain no offset, so decoding retains compatible DST
-resolution: the earlier instant in a fold, and shifting forward by the offset
-change in a gap. Arrow timestamps identify the instant unambiguously. Timezone
-calculations now follow `chrono-tz`; far-future DST results may differ from Jiff.
-
-Python's native `datetime` still only supports years 1 through 9999; for extended
-years, select `to_string(value)` when using the Python binding. JavaScript `Date`
-continues to expose timestamps at millisecond precision.
+Python's native `datetime` only supports years 1 through 9999; for extended
+years, select `to_string(value)` when using the Python binding. JavaScript
+`Date` exposes timestamps at millisecond precision.
 
 ### Semi-Structured Data Types
 

--- a/driver/README.md
+++ b/driver/README.md
@@ -168,9 +168,41 @@ let inserted = insert.end().await?;
 | `DOUBLE`    | `f64`                   |
 | `DECIMAL`   | `String`                |
 | `DATE`      | `chrono::NaiveDate`     |
-| `TIMESTAMP` | `chrono::NaiveDateTime` |
+| `TIMESTAMP` | `chrono::NaiveDateTime`, `chrono::DateTime<chrono_tz::Tz>` |
+| `TIMESTAMP_TZ` | `chrono::DateTime<chrono::FixedOffset>` |
 | `VARCHAR`   | `String`                |
 | `BINARY`    | `Vec<u8>`               |
+
+### Date and timestamp representation
+
+`Value::Timestamp` stores a `chrono::DateTime<chrono_tz::Tz>` in the session
+timezone, and `Value::TimestampTz` stores a `chrono::DateTime<chrono::FixedOffset>`
+with the offset returned by the server. Converting `TIMESTAMP` to
+`chrono::NaiveDateTime` continues to return the **UTC** datetime, not the local
+wall-clock time. Converting a `NaiveDateTime` into `Value` interprets it as UTC.
+
+Both HTTP and Arrow decoding preserve microseconds at the SQL timestamp bounds,
+including `9999-12-31 23:59:59.999999` UTC. A valid UTC instant may display in local
+year 10000 after timezone conversion. Arrow decoding no longer clamps timestamps
+to Jiff's smaller range. The driver's wider representation does not expand the
+server's accepted UTC timestamp range.
+
+**Rust API migration:** the timestamp variants and `ResultFormatSettings::timezone`
+now use Chrono types instead of Jiff. Use `format(...)` instead of `strftime(...)`,
+`timestamp_micros()` instead of `timestamp().as_microsecond()`, and `chrono_tz::Tz`
+for session timezones. The `zoned_to_chrono_datetime` and
+`zoned_to_chrono_fixed_offset` helpers have been removed: the values already are
+Chrono datetimes. Row conversion supports `DateTime<Tz>` and `DateTime<FixedOffset>`
+directly.
+
+HTTP timestamps contain no offset, so decoding retains compatible DST
+resolution: the earlier instant in a fold, and shifting forward by the offset
+change in a gap. Arrow timestamps identify the instant unambiguously. Timezone
+calculations now follow `chrono-tz`; far-future DST results may differ from Jiff.
+
+Python's native `datetime` still only supports years 1 through 9999; for extended
+years, select `to_string(value)` when using the Python binding. JavaScript `Date`
+continues to expose timestamps at millisecond precision.
 
 ### Semi-Structured Data Types
 

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -39,9 +39,7 @@ pub use databend_driver_core::rows::{
     Row, RowIterator, RowStatsIterator, RowWithStats, ServerStats,
 };
 pub use databend_driver_core::value::Interval;
-pub use databend_driver_core::value::{
-    zoned_to_chrono_datetime, zoned_to_chrono_fixed_offset, NumberValue, Value,
-};
+pub use databend_driver_core::value::{NumberValue, Value};
 
 pub use databend_driver_macros::serde_bend;
 pub use databend_driver_macros::TryFromRow;

--- a/driver/tests/driver/select_simple.rs
+++ b/driver/tests/driver/select_simple.rs
@@ -211,6 +211,41 @@ async fn select_datetime() {
 }
 
 #[tokio::test]
+async fn select_datetime_boundaries() {
+    let conn = prepare().await;
+    let is_flight = conn.info().await.handler == "FlightSQL";
+    for (tz, expected) in [
+        (Tz::UTC, "9999-12-31 23:59:59.999999"),
+        (Tz::Asia__Shanghai, "+10000-01-01 07:59:59.999999"),
+    ] {
+        // Flight SQL currently decodes with UTC defaults, not session settings.
+        if is_flight && tz != Tz::UTC {
+            continue;
+        }
+        conn.exec(&format!("SET timezone = '{tz}'")).await.unwrap();
+        // The UTC instant stays within SQL bounds, even when its local year is 10000.
+        let row = conn
+            .query_row(
+                "SELECT to_timestamp(253402300799999999), \
+                 to_timestamp_tz('9999-12-31 23:59:59.999999 +0530')",
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        let values = row.values();
+        assert_eq!(values[0].to_string(), expected);
+        assert_eq!(values[1].to_string(), "9999-12-31 23:59:59.999999 +0530");
+        let naive = NaiveDateTime::try_from(values[0].clone()).unwrap();
+        assert_eq!(naive.and_utc().timestamp_micros(), 253_402_300_799_999_999);
+        let (ts, z): (DateTime<Tz>, DateTime<chrono::FixedOffset>) = row.try_into().unwrap();
+        assert_eq!(ts.timestamp_micros(), 253_402_300_799_999_999);
+        assert_eq!(ts.timezone(), tz);
+        assert_eq!(z.timestamp_micros(), 253_402_280_999_999_999);
+        assert_eq!(z.offset().local_minus_utc(), 19800);
+    }
+}
+
+#[tokio::test]
 async fn select_decimal() {
     let conn = prepare().await;
     let row = conn

--- a/sql/Cargo.toml
+++ b/sql/Cargo.toml
@@ -31,7 +31,6 @@ itertools = "0.14"
 lexical-core = "1.0.5"
 memchr = "2.7"
 roaring = { version = "0.10.12", features = ["serde"] }
-jiff = { workspace = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std", "raw_value"] }
 url = { version = "2.5", default-features = false }

--- a/sql/src/error.rs
+++ b/sql/src/error.rs
@@ -186,12 +186,6 @@ impl From<serde_json::Error> for Error {
     }
 }
 
-impl From<jiff::Error> for Error {
-    fn from(e: jiff::Error) -> Self {
-        Error::Parsing(e.to_string())
-    }
-}
-
 impl From<hex::FromHexError> for Error {
     fn from(e: hex::FromHexError) -> Self {
         Error::Parsing(e.to_string())

--- a/sql/src/value/arrow_decoder.rs
+++ b/sql/src/value/arrow_decoder.rs
@@ -25,6 +25,7 @@ use arrow_array::{
     UInt8Array,
 };
 use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, TimeUnit};
+use chrono::{DateTime, FixedOffset};
 use databend_client::schema::{
     DecimalSize, ARROW_EXT_TYPE_BITMAP, ARROW_EXT_TYPE_EMPTY_ARRAY, ARROW_EXT_TYPE_EMPTY_MAP,
     ARROW_EXT_TYPE_GEOGRAPHY, ARROW_EXT_TYPE_GEOMETRY, ARROW_EXT_TYPE_INTERVAL,
@@ -33,7 +34,6 @@ use databend_client::schema::{
 };
 use databend_client::ResultFormatSettings;
 use ethnum::i256;
-use jiff::{tz, Timestamp};
 use jsonb::RawJsonb;
 
 /// The in-memory representation of the MonthDayMicros variant of the "Interval" logical type.
@@ -45,17 +45,6 @@ struct months_days_micros(pub i128);
 const MICROS_MASK: i128 = 0xFFFFFFFFFFFFFFFF;
 /// Mask for extracting the middle 32 bits (days or months).
 const DAYS_MONTHS_MASK: i128 = 0xFFFFFFFF;
-
-// 9999-12-30T22:00:00Z
-// note: max for jiff is 253402207200999999, 253402207200000000 if for compatible with old databend-query
-const TIMESTAMP_MAX: i64 = 253402207200000000;
-// -009999-01-02T01:59:59Z
-const TIMESTAMP_MIN: i64 = -377705023201000000;
-
-// required by jiff
-fn clamp_ts(ts: i64) -> i64 {
-    ts.clamp(TIMESTAMP_MIN, TIMESTAMP_MAX)
-}
 
 impl months_days_micros {
     #[inline]
@@ -140,16 +129,16 @@ impl
                     match array.as_any().downcast_ref::<Decimal128Array>() {
                         Some(array) => {
                             let v = array.value(seq);
-                            let unix_ts = clamp_ts(v as u64 as i64);
+                            let unix_ts = v as u64 as i64;
                             let offset = (v >> 64) as i32;
-                            let offset = tz::Offset::from_seconds(offset).map_err(|e| {
-                                Error::Parsing(format!("invalid offset: {offset}, {e}"))
+                            let offset = FixedOffset::east_opt(offset).ok_or_else(|| {
+                                Error::Parsing(format!("invalid offset: {offset}"))
                             })?;
-                            let time_zone = tz::TimeZone::fixed(offset);
-                            let timestamp = Timestamp::from_microsecond(unix_ts).map_err(|e| {
-                                Error::Parsing(format!("Invalid timestamp_micros {unix_ts}: {e}"))
-                            })?;
-                            Ok(Value::TimestampTz(timestamp.to_zoned(time_zone)))
+                            let timestamp =
+                                DateTime::from_timestamp_micros(unix_ts).ok_or_else(|| {
+                                    Error::Parsing(format!("Invalid timestamp_micros {unix_ts}"))
+                                })?;
+                            Ok(Value::TimestampTz(timestamp.with_timezone(&offset)))
                         }
                         None => Err(ConvertError::new("Interval", format!("{array:?}")).into()),
                     }
@@ -387,13 +376,14 @@ impl
                                 ))
                                 .into());
                         }
-                        let ts = clamp_ts(array.value(seq));
+                        let ts = array.value(seq);
                         match tz {
                             None => {
-                                let timestamp = Timestamp::from_microsecond(ts).map_err(|e| {
-                                    Error::Parsing(format!("Invalid timestamp_micros {ts}: {e}"))
-                                })?;
-                                let dt = timestamp.to_zoned(settings.timezone.clone());
+                                let timestamp =
+                                    DateTime::from_timestamp_micros(ts).ok_or_else(|| {
+                                        Error::Parsing(format!("Invalid timestamp_micros {ts}"))
+                                    })?;
+                                let dt = timestamp.with_timezone(&settings.timezone);
                                 Ok(Value::Timestamp(dt))
                             }
                             Some(tz) => Err(ConvertError::new("timestamp", format!("{array:?}"))

--- a/sql/src/value/base.rs
+++ b/sql/src/value/base.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use chrono::{DateTime, FixedOffset};
+use chrono_tz::Tz;
 use databend_client::schema::{DataType, DecimalDataType, DecimalSize, NumberDataType};
 use databend_client::GeometryDataType;
 use ethnum::i256;
-use jiff::Zoned;
 use std::borrow::Cow;
 
 // Thu 1970-01-01 is R.D. 719163
@@ -83,8 +84,8 @@ pub enum Value {
     String(String),
     Number(NumberValue),
     /// Microseconds from 1970-01-01 00:00:00 UTC
-    Timestamp(Zoned),
-    TimestampTz(Zoned),
+    Timestamp(DateTime<Tz>),
+    TimestampTz(DateTime<FixedOffset>),
     Date(i32),
     Array(Vec<Value>),
     Map(Vec<(Value, Value)>),

--- a/sql/src/value/convert.rs
+++ b/sql/src/value/convert.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use chrono::{
-    DateTime, Datelike, FixedOffset, LocalResult, NaiveDate, NaiveDateTime, TimeZone, Utc,
-};
+use chrono::{DateTime, Datelike, FixedOffset, NaiveDate, NaiveDateTime};
 use chrono_tz::Tz;
 use std::collections::HashMap;
 use std::hash::Hash;
@@ -22,7 +20,6 @@ use std::hash::Hash;
 use crate::error::{ConvertError, Error, Result};
 
 use super::{NumberValue, Value, DAYS_FROM_CE};
-use jiff::{tz::TimeZone as JiffTimeZone, Timestamp, Zoned};
 
 impl TryFrom<Value> for bool {
     type Error = Error;
@@ -73,62 +70,11 @@ impl_try_from_number_value!(i64);
 impl_try_from_number_value!(f32);
 impl_try_from_number_value!(f64);
 
-fn unix_micros_from_zoned(zdt: &Zoned) -> i64 {
-    zdt.timestamp().as_microsecond()
-}
-
-fn naive_datetime_from_micros(micros: i64) -> Result<NaiveDateTime> {
-    DateTime::<Utc>::from_timestamp_micros(micros)
-        .map(|dt| dt.naive_utc())
-        .ok_or_else(|| Error::Parsing(format!("invalid unix timestamp {micros}")))
-}
-
-pub fn zoned_to_chrono_datetime(zdt: &Zoned) -> Result<DateTime<Tz>> {
-    let tz_name = zdt.time_zone().iana_name().ok_or_else(|| {
-        ConvertError::new(
-            "DateTime",
-            "timestamp does not contain an IANA time zone".to_string(),
-        )
-    })?;
-    let tz: Tz = tz_name.parse().map_err(|_| {
-        ConvertError::new(
-            "DateTime",
-            format!("invalid time zone identifier {tz_name}"),
-        )
-    })?;
-    let micros = unix_micros_from_zoned(zdt);
-    match tz.timestamp_micros(micros) {
-        LocalResult::Single(dt) => Ok(dt),
-        LocalResult::Ambiguous(dt, _) => Ok(dt),
-        LocalResult::None => Err(Error::Parsing(format!(
-            "time {micros} not exists in timezone {tz_name}"
-        ))),
-    }
-}
-
-pub fn zoned_to_chrono_fixed_offset(zdt: &Zoned) -> Result<DateTime<FixedOffset>> {
-    let offset_seconds = zdt.offset().seconds();
-    let offset = FixedOffset::east_opt(offset_seconds)
-        .ok_or_else(|| Error::Parsing(format!("invalid offset {offset_seconds}")))?;
-    let micros = unix_micros_from_zoned(zdt);
-    let naive = naive_datetime_from_micros(micros)?;
-    Ok(DateTime::<FixedOffset>::from_naive_utc_and_offset(
-        naive, offset,
-    ))
-}
-
-fn zoned_from_naive_datetime(naive_dt: &NaiveDateTime) -> Zoned {
-    let micros = naive_dt.and_utc().timestamp_micros();
-    let timestamp = Timestamp::from_microsecond(micros)
-        .expect("NaiveDateTime out of range for Timestamp conversion");
-    timestamp.to_zoned(JiffTimeZone::UTC)
-}
-
 impl TryFrom<Value> for NaiveDateTime {
     type Error = Error;
     fn try_from(val: Value) -> Result<Self> {
         match val {
-            Value::Timestamp(dt) => naive_datetime_from_micros(unix_micros_from_zoned(&dt)),
+            Value::Timestamp(dt) => Ok(dt.naive_utc()),
             _ => Err(ConvertError::new("NaiveDateTime", format!("{val}")).into()),
         }
     }
@@ -138,8 +84,18 @@ impl TryFrom<Value> for DateTime<Tz> {
     type Error = Error;
     fn try_from(val: Value) -> Result<Self> {
         match val {
-            Value::Timestamp(dt) => zoned_to_chrono_datetime(&dt),
+            Value::Timestamp(dt) => Ok(dt),
             _ => Err(ConvertError::new("DateTime", format!("{val}")).into()),
+        }
+    }
+}
+
+impl TryFrom<Value> for DateTime<FixedOffset> {
+    type Error = Error;
+    fn try_from(val: Value) -> Result<Self> {
+        match val {
+            Value::TimestampTz(dt) => Ok(dt),
+            _ => Err(ConvertError::new("DateTime<FixedOffset>", format!("{val}")).into()),
         }
     }
 }
@@ -480,13 +436,13 @@ impl From<&NaiveDate> for Value {
 
 impl From<NaiveDateTime> for Value {
     fn from(naive_dt: NaiveDateTime) -> Self {
-        Value::Timestamp(zoned_from_naive_datetime(&naive_dt))
+        Value::Timestamp(naive_dt.and_utc().with_timezone(&Tz::UTC))
     }
 }
 
 impl From<&NaiveDateTime> for Value {
     fn from(naive_dt: &NaiveDateTime) -> Self {
-        Value::Timestamp(zoned_from_naive_datetime(naive_dt))
+        Value::Timestamp(naive_dt.and_utc().with_timezone(&Tz::UTC))
     }
 }
 

--- a/sql/src/value/format/display.rs
+++ b/sql/src/value/format/display.rs
@@ -83,7 +83,7 @@ impl Value {
                 }
             }
             Value::Timestamp(dt) => {
-                let formatted = dt.strftime(TIMESTAMP_FORMAT);
+                let formatted = dt.format(TIMESTAMP_FORMAT);
                 if raw {
                     write!(f, "{formatted}")
                 } else {
@@ -91,7 +91,7 @@ impl Value {
                 }
             }
             Value::TimestampTz(dt) => {
-                let formatted = dt.strftime(TIMESTAMP_TIMEZONE_FORMAT);
+                let formatted = dt.format(TIMESTAMP_TIMEZONE_FORMAT);
                 if raw {
                     write!(f, "{formatted}")
                 } else {

--- a/sql/src/value/format/into_string.rs
+++ b/sql/src/value/format/into_string.rs
@@ -14,7 +14,7 @@
 
 use crate::_macro_internal::{Error, Value};
 use crate::error::ConvertError;
-use crate::value::base::{DAYS_FROM_CE, TIMESTAMP_FORMAT};
+use crate::value::base::{DAYS_FROM_CE, TIMESTAMP_FORMAT, TIMESTAMP_TIMEZONE_FORMAT};
 use crate::value::format::display::{display_decimal_128, display_decimal_256};
 use crate::value::NumberValue;
 use chrono::NaiveDate;
@@ -41,7 +41,8 @@ impl TryFrom<Value> for String {
                     })?;
                 Ok(date.format("%Y-%m-%d").to_string())
             }
-            Value::Timestamp(dt) => Ok(dt.strftime(TIMESTAMP_FORMAT).to_string()),
+            Value::Timestamp(dt) => Ok(dt.format(TIMESTAMP_FORMAT).to_string()),
+            Value::TimestampTz(dt) => Ok(dt.format(TIMESTAMP_TIMEZONE_FORMAT).to_string()),
             _ => Err(ConvertError::new("string", format!("{val:?}")).into()),
         }
     }

--- a/sql/src/value/format/result_encode.rs
+++ b/sql/src/value/format/result_encode.rs
@@ -96,11 +96,11 @@ impl Value {
                 }
             }
             Value::Timestamp(dt) => {
-                let s = dt.strftime(TIMESTAMP_FORMAT).to_string();
+                let s = dt.format(TIMESTAMP_FORMAT).to_string();
                 Self::write_string(bytes, &s, raw);
             }
             Value::TimestampTz(dt) => {
-                let s = dt.strftime(TIMESTAMP_TIMEZONE_FORMAT).to_string();
+                let s = dt.format(TIMESTAMP_TIMEZONE_FORMAT).to_string();
                 Self::write_string(bytes, &s, raw);
             }
             Value::Date(i) => {

--- a/sql/src/value/format/to_sql_string.rs
+++ b/sql/src/value/format/to_sql_string.rs
@@ -48,10 +48,10 @@ impl Value {
                 }
             },
             Value::Timestamp(dt) => {
-                serde_json::Value::String(dt.strftime(TIMESTAMP_FORMAT).to_string())
+                serde_json::Value::String(dt.format(TIMESTAMP_FORMAT).to_string())
             }
             Value::TimestampTz(dt) => {
-                serde_json::Value::String(dt.strftime(TIMESTAMP_TIMEZONE_FORMAT).to_string())
+                serde_json::Value::String(dt.format(TIMESTAMP_TIMEZONE_FORMAT).to_string())
             }
             Value::Date(d) => {
                 let date = NaiveDate::from_num_days_from_ce_opt(*d + DAYS_FROM_CE).unwrap();
@@ -103,10 +103,10 @@ impl Value {
             Value::String(s) => format!("'{}'", s),
             Value::Number(n) => n.to_string(),
             Value::Timestamp(dt) => {
-                format!("'{}'", dt.strftime(TIMESTAMP_FORMAT))
+                format!("'{}'", dt.format(TIMESTAMP_FORMAT))
             }
             Value::TimestampTz(dt) => {
-                let formatted = dt.strftime(TIMESTAMP_TIMEZONE_FORMAT);
+                let formatted = dt.format(TIMESTAMP_TIMEZONE_FORMAT);
                 format!("'{formatted}'")
             }
             Value::Date(d) => {

--- a/sql/src/value/mod.rs
+++ b/sql/src/value/mod.rs
@@ -20,7 +20,6 @@ mod interval;
 mod string_decoder;
 
 pub use base::{GeoValue, NumberValue, Value};
-pub use convert::{zoned_to_chrono_datetime, zoned_to_chrono_fixed_offset};
 pub use interval::Interval;
 
 use base::{DAYS_FROM_CE, TIMESTAMP_FORMAT, TIMESTAMP_TIMEZONE_FORMAT};

--- a/sql/src/value/string_decoder.rs
+++ b/sql/src/value/string_decoder.rs
@@ -20,12 +20,12 @@ use crate::cursor_ext::{
 };
 use crate::error::{ConvertError, Result};
 use crate::value::base::GeoValue;
-use chrono::{Datelike, NaiveDate};
+use chrono::{DateTime, Datelike, LocalResult, NaiveDate, NaiveDateTime, Offset, TimeZone as _};
+use chrono_tz::{GapInfo, Tz as TimeZone};
 use databend_client::schema::{DataType, DecimalDataType, DecimalSize, NumberDataType};
 use databend_client::ResultFormatSettings;
 use ethnum::i256;
 use hex;
-use jiff::{civil::DateTime as JiffDateTime, tz::TimeZone, Zoned};
 use serde::Deserialize;
 use serde_json::{value::RawValue, Deserializer};
 use std::io::{BufRead, Cursor};
@@ -109,7 +109,7 @@ impl TryFrom<(&DataType, String, &ResultFormatSettings)> for Value {
             }
             DataType::Timestamp => parse_timestamp(v.as_str(), &settings.timezone),
             DataType::TimestampTz => {
-                let t = Zoned::strptime(TIMESTAMP_TIMEZONE_FORMAT, v.as_str())?;
+                let t = DateTime::parse_from_str(v.as_str(), TIMESTAMP_TIMEZONE_FORMAT)?;
                 Ok(Self::TimestampTz(t))
             }
             DataType::Date => Ok(Self::Date(
@@ -332,7 +332,7 @@ impl ValueDecoder {
             reader.read_quoted_text(&mut buf, b'\'')?;
         }
         let v = unsafe { std::str::from_utf8_unchecked(&buf) };
-        let t = Zoned::strptime(TIMESTAMP_TIMEZONE_FORMAT, v)?;
+        let t = DateTime::parse_from_str(v, TIMESTAMP_TIMEZONE_FORMAT)?;
         Ok(Value::TimestampTz(t))
     }
 
@@ -503,13 +503,19 @@ impl ValueDecoder {
 }
 
 fn parse_timestamp(ts_string: &str, tz: &TimeZone) -> Result<Value> {
-    let local = JiffDateTime::strptime(TIMESTAMP_FORMAT, ts_string)?;
-    let dt_with_tz = local.to_zoned(tz.clone()).map_err(|e| {
-        Error::Parsing(format!(
-            "time {ts_string} not exists in timezone {tz:?}: {e}"
-        ))
-    })?;
-    Ok(Value::Timestamp(dt_with_tz))
+    let local = NaiveDateTime::parse_from_str(ts_string, TIMESTAMP_FORMAT)?;
+    // Preserve Jiff's compatible disambiguation: choose the earlier instant in
+    // a fold, and shift forward by the offset change in a gap (not necessarily
+    // one hour). HTTP timestamps have no offset to distinguish a fold.
+    let dt = match tz.from_local_datetime(&local) {
+        LocalResult::Single(dt) | LocalResult::Ambiguous(dt, _) => Some(dt),
+        LocalResult::None => GapInfo::new(&local, tz)
+            .and_then(|gap| gap.begin)
+            .and_then(|(_, offset)| offset.fix().from_local_datetime(&local).single())
+            .map(|dt| dt.with_timezone(tz)),
+    }
+    .ok_or_else(|| Error::Parsing(format!("time {ts_string} not exists in timezone {tz}")))?;
+    Ok(Value::Timestamp(dt))
 }
 
 fn parse_decimal(text: &str, size: DecimalSize) -> Result<NumberValue> {


### PR DESCRIPTION
## Summary

Replace Jiff-backed timestamps with Chrono to fix decoding failures and
silent Arrow clamping near Databend's timestamp bounds.

- Preserve `9999-12-31 23:59:59.999999` UTC, microsecond precision, and
  explicit `TIMESTAMP_TZ` offsets.
- Handle local year 10000 produced by timezone conversion without
  expanding the server's accepted UTC range.
- Update formatting, parameter serialization, and Python/Node.js bindings.

## Compatibility

This is a breaking Rust API change, intended for release **0.35.0**:

- Timestamp variants now contain Chrono `DateTime` values.
- `ResultFormatSettings::timezone` now uses `chrono_tz::Tz`.
- Remove the `zoned_to_chrono_*` conversion helpers.

Existing row conversions to `NaiveDateTime` and `DateTime<Tz>` remain
supported. Python/Node.js retain their native datetime/Date types and
existing range/precision limits. Far-future DST behavior follows
chrono-tz and may differ from Jiff.

## Validation

Validated against Databend Query `v1.2.911-nightly-3b719621c4`:

Link: https://github.com/databendlabs/databend/pull/20425

- Datetime integration tests pass over HTTP JSON, HTTP Arrow, and
  Flight SQL (UTC boundary coverage for Flight SQL).
- Rust formatting, Clippy, and Python/Node.js compilation checks pass,
  including Python cp38.