### PR TITLE
fix(deps): disable unused Actix HTTP/2 support

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'the rust cache key suffix'
     required: false
     default: ''
+  toolchain:
+    description: 'the rust toolchain to install'
+    required: false
+    default: stable
   target:
     description: 'the rust target to build'
     required: false
@@ -20,7 +24,7 @@ runs:
     - uses: dtolnay/rust-toolchain@stable
       id: toolchain
       with:
-        toolchain: stable
+        toolchain: ${{ inputs.toolchain }}
         targets: ${{ inputs.target }}
 
     - name: Setup sccache

--- a/.github/workflows/bindings.nodejs.yml
+++ b/.github/workflows/bindings.nodejs.yml
@@ -31,13 +31,21 @@ jobs:
     needs: check
     name: build-${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
+    env:
+      # Override rust-toolchain.toml for the pinned cross-compilation jobs.
+      RUSTUP_TOOLCHAIN: ${{ matrix.toolchain || 'stable' }}
     strategy:
       matrix:
         include:
           - { target: x86_64-unknown-linux-gnu, runner: ubuntu-22.04 }
-          - { target: aarch64-unknown-linux-gnu, runner: ubuntu-22.04 }
+          # Pin both ARM64 Linux builds: Rust 1.98 adds --fix-cortex-a53-843419,
+          # which zig cc rejects through NAPI CLI 2.x's linker wrapper.
+          # This preserves the previous build behavior, without the new erratum mitigation.
+          # Remove the pins once the linker integration supports the mitigation:
+          # https://codeberg.org/ziglang/zig/issues/36624
+          - { target: aarch64-unknown-linux-gnu, runner: ubuntu-22.04, toolchain: '1.97.1' }
           - { target: x86_64-unknown-linux-musl, runner: ubuntu-latest }
-          - { target: aarch64-unknown-linux-musl, runner: ubuntu-latest }
+          - { target: aarch64-unknown-linux-musl, runner: ubuntu-latest, toolchain: '1.97.1' }
           - { target: x86_64-pc-windows-msvc, runner: windows-latest }
           - { target: aarch64-pc-windows-msvc, runner: windows-latest }
           - { target: x86_64-apple-darwin, runner: macos-latest }
@@ -49,6 +57,7 @@ jobs:
         with:
           cache-key: bindings-nodejs-${{ matrix.target }}
           target: ${{ matrix.target }}
+          toolchain: ${{ matrix.toolchain || 'stable' }}
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/bindings/python/src/blocking.rs
+++ b/bindings/python/src/blocking.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::mem::take;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
@@ -473,7 +474,7 @@ impl BlockingDatabendCursor {
 
     #[pyo3(signature = (size=1))]
     pub fn fetchmany(&mut self, py: Python, size: Option<usize>) -> PyResult<Vec<Row>> {
-        let mut result = self.buffer.drain(..).collect::<Vec<_>>();
+        let mut result = take(&mut self.buffer);
         if let Some(ref rows) = self.rows {
             let size = size.unwrap_or(1);
             while result.len() < size {
@@ -492,7 +493,7 @@ impl BlockingDatabendCursor {
     }
 
     pub fn fetchall(&mut self, py: Python) -> PyResult<Vec<Row>> {
-        let mut result = self.buffer.drain(..).collect::<Vec<_>>();
+        let mut result = take(&mut self.buffer);
         match self.rows.take() {
             Some(rows) => {
                 let fetched = wait_for_future(py, async move {

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,7 +16,16 @@ databend-client = { workspace = true }
 databend-driver = { workspace = true, features = ["rustls", "flight-sql"] }
 tokio-stream = { workspace = true }
 
-actix-web = "4.11"
+# The Web UI uses HTTP/1; disable HTTP/2 to avoid h2 0.3 (RUSTSEC-2026-0258).
+actix-web = { version = "4.11", default-features = false, features = [
+    "macros",
+    "compress-brotli",
+    "compress-gzip",
+    "compress-zstd",
+    "cookies",
+    "unicode",
+    "compat",
+] }
 anyhow = "1.0"
 arrow = { workspace = true }
 async-recursion = "1.1.1"

--- a/cli/src/web.rs
+++ b/cli/src/web.rs
@@ -285,7 +285,7 @@ async fn execute_query(req: web::Json<QueryRequest>) -> impl Responder {
     if req.kind == 3 {
         return run_python_script(&req.sql, &effective_dsn)
             .await
-            .unwrap_or_else(|err| err);
+            .unwrap_or_else(|err| *err);
     }
 
     let sql = req.to_sql();
@@ -414,13 +414,13 @@ async fn execute_query(req: web::Json<QueryRequest>) -> impl Responder {
     })
 }
 
-async fn run_python_script(code: &str, dsn: &str) -> Result<HttpResponse, HttpResponse> {
+async fn run_python_script(code: &str, dsn: &str) -> Result<HttpResponse, Box<HttpResponse>> {
     match StdCommand::new("docker").arg("--version").output() {
         Ok(output) if output.status.success() => {}
         _ => {
-            return Err(HttpResponse::InternalServerError().json(serde_json::json!({
+            return Err(Box::new(HttpResponse::InternalServerError().json(serde_json::json!({
                 "error": "Docker is required to execute Python scripts. Please install Docker and try again."
-            })));
+            }))));
         }
     }
 
@@ -510,9 +510,11 @@ client = BlockingDatabendClient(_BENDSQL_DSN)
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": format!("Python execution failed: {}", stderr.trim())
-        })));
+        return Err(Box::new(HttpResponse::InternalServerError().json(
+            serde_json::json!({
+                "error": format!("Python execution failed: {}", stderr.trim())
+            }),
+        )));
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
- Disable unused Actix HTTP/2 support to remove `h2 0.3`, fixing
  [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258).
  The Web UI already uses HTTP/1; driver HTTP/2 support is unchanged.
- Fix Clippy warnings in Python cursor fetching and Web UI error handling.
- Temporarily pin ARM64 Linux Node.js builds to Rust 1.97.1 due to
  [Zig #36624](https://codeberg.org/ziglang/zig/issues/36624).
  Other builds remain on stable.